### PR TITLE
Clean up UFS/FFS namespace

### DIFF
--- a/lib/libstand/ufs.c
+++ b/lib/libstand/ufs.c
@@ -157,7 +157,7 @@ read_inode(inumber, f)
 	buf = malloc(fs->fs_bsize);
 	twiddle(1);
 	rc = (f->f_dev->dv_strategy)(f->f_devdata, F_READ,
-		fsbtodb(fs, ino_to_fsba(fs, inumber)), fs->fs_bsize,
+		FFS_FSBTODB(fs, ino_to_fsba(fs, inumber)), fs->fs_bsize,
 		buf, &rsize);
 	if (rc)
 		goto out;
@@ -267,7 +267,7 @@ block_map(f, file_block, disk_block_p)
 					malloc(fs->fs_bsize);
 			twiddle(1);
 			rc = (f->f_dev->dv_strategy)(f->f_devdata, F_READ,
-				fsbtodb(fp->f_fs, ind_block_num),
+				FFS_FSBTODB(fp->f_fs, ind_block_num),
 				fs->fs_bsize,
 				fp->f_blk[level],
 				&fp->f_blksize[level]);
@@ -348,7 +348,7 @@ buf_write_file(f, buf_p, size_p)
 
 		twiddle(4);
 		rc = (f->f_dev->dv_strategy)(f->f_devdata, F_READ,
-			fsbtodb(fs, disk_block),
+			FFS_FSBTODB(fs, disk_block),
 			block_size, fp->f_buf, &fp->f_buf_size);
 		if (rc)
 			return (rc);
@@ -367,7 +367,7 @@ buf_write_file(f, buf_p, size_p)
 
 	twiddle(4);
 	rc = (f->f_dev->dv_strategy)(f->f_devdata, F_WRITE,
-		fsbtodb(fs, disk_block),
+		FFS_FSBTODB(fs, disk_block),
 		block_size, fp->f_buf, &fp->f_buf_size);
 	return (rc);
 }
@@ -408,7 +408,7 @@ buf_read_file(f, buf_p, size_p)
 		} else {
 			twiddle(4);
 			rc = (f->f_dev->dv_strategy)(f->f_devdata, F_READ,
-				fsbtodb(fs, disk_block),
+				FFS_FSBTODB(fs, disk_block),
 				block_size, fp->f_buf, &fp->f_buf_size);
 			if (rc)
 				return (rc);
@@ -651,7 +651,7 @@ ufs_open(upath, f)
 				
 				twiddle(1);
 				rc = (f->f_dev->dv_strategy)(f->f_devdata,
-					F_READ, fsbtodb(fs, disk_block),
+					F_READ, FFS_FSBTODB(fs, disk_block),
 					fs->fs_bsize, buf, &buf_size);
 				if (rc)
 					goto out;

--- a/lib/libufs/cgroup.c
+++ b/lib/libufs/cgroup.c
@@ -193,7 +193,7 @@ cgread1(struct uufsd *disk, int c)
 	if ((unsigned)c >= fs->fs_ncg) {
 		return (0);
 	}
-	if (bread(disk, fsbtodb(fs, cgtod(fs, c)), disk->d_cgunion.d_buf,
+	if (bread(disk, FFS_FSBTODB(fs, cgtod(fs, c)), disk->d_cgunion.d_buf,
 	    fs->fs_bsize) == -1) {
 		ERROR(disk, "unable to read cylinder group");
 		return (-1);
@@ -214,7 +214,7 @@ cgwrite1(struct uufsd *disk, int c)
 	struct fs *fs;
 
 	fs = &disk->d_fs;
-	if (bwrite(disk, fsbtodb(fs, cgtod(fs, c)),
+	if (bwrite(disk, FFS_FSBTODB(fs, cgtod(fs, c)),
 	    disk->d_cgunion.d_buf, fs->fs_bsize) == -1) {
 		ERROR(disk, "unable to write cylinder group");
 		return (-1);

--- a/lib/libufs/inode.c
+++ b/lib/libufs/inode.c
@@ -72,7 +72,7 @@ getino(struct uufsd *disk, void **dino, ino_t inode, int *mode)
 	}
 	if (inode >= min && inode < max)
 		goto gotit;
-	bread(disk, fsbtodb(fs, ino_to_fsba(fs, inode)), inoblock,
+	bread(disk, FFS_FSBTODB(fs, ino_to_fsba(fs, inode)), inoblock,
 	    fs->fs_bsize);
 	disk->d_inomin = min = inode - (inode % FFS_INOPB(fs));
 	disk->d_inomax = max = min + FFS_INOPB(fs);
@@ -104,7 +104,7 @@ putino(struct uufsd *disk)
 		ERROR(disk, "No inode block allocated");
 		return (-1);
 	}
-	if (bwrite(disk, fsbtodb(fs, ino_to_fsba(&disk->d_fs, disk->d_inomin)),
+	if (bwrite(disk, FFS_FSBTODB(fs, ino_to_fsba(&disk->d_fs, disk->d_inomin)),
 	    disk->d_inoblock, disk->d_fs.fs_bsize) <= 0)
 		return (-1);
 	return (0);

--- a/lib/libufs/sblock.c
+++ b/lib/libufs/sblock.c
@@ -88,7 +88,7 @@ sbread(struct uufsd *disk)
 		errno = ENOENT;
 		return (-1);
 	}
-	disk->d_bsize = fs->fs_fsize / fsbtodb(fs, 1);
+	disk->d_bsize = fs->fs_fsize / FFS_FSBTODB(fs, 1);
 	disk->d_sblock = superblock / disk->d_bsize;
 	/*
 	 * Read in the superblock summary information.
@@ -106,7 +106,7 @@ sbread(struct uufsd *disk)
 		size = fs->fs_bsize;
 		if (i + fs->fs_frag > blks)
 			size = (blks - i) * fs->fs_fsize;
-		if (bread(disk, fsbtodb(fs, fs->fs_csaddr + i), block, size)
+		if (bread(disk, FFS_FSBTODB(fs, fs->fs_csaddr + i), block, size)
 		    == -1) {
 			ERROR(disk, "Failed to read sb summary information");
 			free(fs->fs_csp);
@@ -150,7 +150,7 @@ sbwrite(struct uufsd *disk, int all)
 		size = fs->fs_bsize;
 		if (i + fs->fs_frag > blks)
 			size = (blks - i) * fs->fs_fsize;
-		if (bwrite(disk, fsbtodb(fs, fs->fs_csaddr + i), space, size)
+		if (bwrite(disk, FFS_FSBTODB(fs, fs->fs_csaddr + i), space, size)
 		    == -1) {
 			ERROR(disk, "Failed to write sb summary information");
 			return (-1);
@@ -159,7 +159,7 @@ sbwrite(struct uufsd *disk, int all)
 	}
 	if (all) {
 		for (i = 0; i < fs->fs_ncg; i++)
-			if (bwrite(disk, fsbtodb(fs, cgsblock(fs, i)),
+			if (bwrite(disk, FFS_FSBTODB(fs, cgsblock(fs, i)),
 			    fs, SBLOCKSIZE) == -1) {
 				ERROR(disk, "failed to update a superblock");
 				return (-1);

--- a/sbin/badsect/badsect.c
+++ b/sbin/badsect/badsect.c
@@ -135,7 +135,7 @@ main(int argc, char *argv[])
 		 * of BSD before 4.4 because dev_t was 16 bits and another
 		 * bit was lost by bogus sign extensions.
 		 */
-		diskbn = dbtofsb(fs, number);
+		diskbn = FFS_DBTOFSB(fs, number);
 		if ((dev_t)diskbn != diskbn) {
 			printf("sector %ld cannot be represented as a dev_t\n",
 			    (long)number);
@@ -157,7 +157,7 @@ chkuse(daddr_t blkno, int cnt)
 	int cg;
 	daddr_t fsbn, bn;
 
-	fsbn = dbtofsb(fs, blkno);
+	fsbn = FFS_DBTOFSB(fs, blkno);
 	if ((unsigned)(fsbn+cnt) > fs->fs_size) {
 		printf("block %ld out of range of file system\n", (long)blkno);
 		return (1);

--- a/sbin/clri/clri.c
+++ b/sbin/clri/clri.c
@@ -118,7 +118,7 @@ main(int argc, char *argv[])
 
 		/* read in the appropriate block. */
 		offset = ino_to_fsba(sbp, inonum);	/* inode to fs blk */
-		offset = fsbtodb(sbp, offset);		/* fs blk disk blk */
+		offset = FFS_FSBTODB(sbp, offset);	/* fs blk disk blk */
 		offset *= DEV_BSIZE;			/* disk blk to bytes */
 
 		/* seek and read the block */

--- a/sbin/dump/main.c
+++ b/sbin/dump/main.c
@@ -448,7 +448,7 @@ main(int argc, char *argv[])
 	}
 	if (sblock_try[i] == -1)
 		quit("Cannot find file system superblock\n");
-	dev_bsize = sblock->fs_fsize / fsbtodb(sblock, 1);
+	dev_bsize = sblock->fs_fsize / FFS_FSBTODB(sblock, 1);
 	dev_bshift = ffs(dev_bsize) - 1;
 	if (dev_bsize != (1 << dev_bshift))
 		quit("dev_bsize (%ld) is not a power of 2", dev_bsize);

--- a/sbin/dump/tape.c
+++ b/sbin/dump/tape.c
@@ -177,7 +177,7 @@ dumpblock(ufs2_daddr_t blkno, int size)
 	int avail, tpblks;
 	ufs2_daddr_t dblkno;
 
-	dblkno = fsbtodb(sblock, blkno);
+	dblkno = FFS_FSBTODB(sblock, blkno);
 	tpblks = size >> tp_bshift;
 	while ((avail = MIN(tpblks, ntrec - trecno)) > 0) {
 		slp->req[trecno].dblk = dblkno;

--- a/sbin/dump/traverse.c
+++ b/sbin/dump/traverse.c
@@ -160,7 +160,7 @@ mapfiles(ino_t maxino, long *tapesize)
 		quit("mapfiles: cannot allocate memory.\n");
 	for (cg = 0; cg < sblock->fs_ncg; cg++) {
 		ino = cg * sblock->fs_ipg;
-		bread(fsbtodb(sblock, cgtod(sblock, cg)), (char *)cgp,
+		bread(FFS_FSBTODB(sblock, cgtod(sblock, cg)), (char *)cgp,
 		    sblock->fs_cgsize);
 		if (sblock->fs_magic == FS_UFS2_MAGIC)
 			inosused = cgp->cg_initediblk;
@@ -341,7 +341,7 @@ dirindir(
 	int ret = 0;
 	int i;
 
-	bread(fsbtodb(sblock, blkno), (char *)&idblk, (int)sblock->fs_bsize);
+	bread(FFS_FSBTODB(sblock, blkno), (char *)&idblk, (int)sblock->fs_bsize);
 	if (ind_level <= 0) {
 		for (i = 0; *filesize > 0 && i < NINDIR(sblock); i++) {
 			if (sblock->fs_magic == FS_UFS1_MAGIC)
@@ -394,7 +394,7 @@ searchdir(
 
 	if (dblk == NULL && (dblk = malloc(sblock->fs_bsize)) == NULL)
 		quit("searchdir: cannot allocate indirect memory.\n");
-	bread(fsbtodb(sblock, blkno), dblk, (int)size);
+	bread(FFS_FSBTODB(sblock, blkno), dblk, (int)size);
 	if (filesize < size)
 		size = filesize;
 	for (loc = 0; loc < size; ) {
@@ -590,7 +590,7 @@ dmpindir(union dinode *dp, ino_t ino, ufs2_daddr_t blk, int ind_level,
 	int i, cnt, last;
 
 	if (blk != 0)
-		bread(fsbtodb(sblock, blk), (char *)&idblk,
+		bread(FFS_FSBTODB(sblock, blk), (char *)&idblk,
 		    (int)sblock->fs_bsize);
 	else
 		memset(&idblk, 0, sblock->fs_bsize);
@@ -882,7 +882,7 @@ getino(ino_t inum, int *modep)
 	curino = inum;
 	if (inum >= minino && inum < maxino)
 		goto gotit;
-	bread(fsbtodb(sblock, ino_to_fsba(sblock, inum)), inoblock,
+	bread(FFS_FSBTODB(sblock, ino_to_fsba(sblock, inum)), inoblock,
 	    (int)sblock->fs_bsize);
 	minino = inum - (inum % FFS_INOPB(sblock));
 	maxino = minino + FFS_INOPB(sblock);
@@ -958,7 +958,7 @@ loop:
 		}
 	}
 bad:
-	if (blkno + (size / dev_bsize) > fsbtodb(sblock, sblock->fs_size)) {
+	if (blkno + (size / dev_bsize) > FFS_FSBTODB(sblock, sblock->fs_size)) {
 		/*
 		 * Trying to read the final fragment.
 		 *

--- a/sbin/dumpfs/dumpfs.c
+++ b/sbin/dumpfs/dumpfs.c
@@ -282,7 +282,7 @@ dumpfs(const char *name)
 		(uintmax_t)afs.fs_providersize);
 	printf("\ncs[].cs_(nbfree,ndir,nifree,nffree):\n\t");
 	afs.fs_csp = calloc(1, afs.fs_cssize);
-	if (bread(&disk, fsbtodb(&afs, afs.fs_csaddr), afs.fs_csp, afs.fs_cssize) == -1)
+	if (bread(&disk, FFS_FSBTODB(&afs, afs.fs_csaddr), afs.fs_csp, afs.fs_cssize) == -1)
 		goto err;
 	for (i = 0; i < afs.fs_ncg; i++) {
 		struct csum *cs = &afs.fs_cs(&afs, i);
@@ -318,7 +318,7 @@ dumpcg(void)
 	int i, j;
 
 	printf("\ncg %d:\n", disk.d_lcg);
-	cur = fsbtodb(&afs, cgtod(&afs, disk.d_lcg)) * disk.d_bsize;
+	cur = FFS_FSBTODB(&afs, cgtod(&afs, disk.d_lcg)) * disk.d_bsize;
 	switch (disk.d_ufs) {
 	case 2:
 		cgtime = acg.cg_time;
@@ -440,7 +440,7 @@ marshal(const char *name)
 		break;
 	}
 	/* -p..r unimplemented */
-	printf("-s %jd ", (intmax_t)fsbtodb(fs, fs->fs_size));
+	printf("-s %jd ", (intmax_t)FFS_FSBTODB(fs, fs->fs_size));
 	if (fs->fs_flags & FS_TRIM)
 		printf("-t ");
 	printf("%s ", disk.d_name);

--- a/sbin/ffsinfo/ffsinfo.c
+++ b/sbin/ffsinfo/ffsinfo.c
@@ -250,7 +250,7 @@ main(int argc, char **argv)
 
 		/* get the cylinder summary into the memory ... */
 		for (i = 0; i < sblock.fs_cssize; i += sblock.fs_bsize) {
-			if (bread(&disk, fsbtodb(&sblock,
+			if (bread(&disk, FFS_FSBTODB(&sblock,
 			    sblock.fs_csaddr + ffs_numfrags(&sblock, i)), 
 			    (void *)(((char *)fscs)+i), 
 			    (size_t)(sblock.fs_cssize-i < sblock.fs_bsize ?
@@ -275,7 +275,7 @@ main(int argc, char **argv)
 			snprintf(dbg_line, sizeof(dbg_line), "cgr %d", cylno);
 			if (cfg_lv & 0x002) {
 				/* dump the superblock copies */
-				if (bread(&disk, fsbtodb(&sblock,
+				if (bread(&disk, FFS_FSBTODB(&sblock,
 				    cgsblock(&sblock, cylno)), 
 				    (void *)&osblock, SBLOCKSIZE) == -1)
 					err(1, "bread: %s", disk.d_error);
@@ -286,7 +286,7 @@ main(int argc, char **argv)
 			 * Read the cylinder group and dump whatever was
 			 * requested.
 			 */
-			if (bread(&disk, fsbtodb(&sblock,
+			if (bread(&disk, FFS_FSBTODB(&sblock,
 			    cgtod(&sblock, cylno)), (void *)&acg,
 			    (size_t)sblock.fs_cgsize) == -1)
 				err(1, "bread: %s", disk.d_error);
@@ -382,7 +382,7 @@ dump_whole_ufs1_inode(ino_t inode, int level)
 		/*
 		 * Dump single indirect block.
 		 */
-		if (bread(&disk, fsbtodb(&sblock, ino->di_ib[0]), (void *)&i1blk, 
+		if (bread(&disk, FFS_FSBTODB(&sblock, ino->di_ib[0]), (void *)&i1blk, 
 			(size_t)sblock.fs_bsize) == -1) {
 			err(1, "bread: %s", disk.d_error);
 		}
@@ -398,7 +398,7 @@ dump_whole_ufs1_inode(ino_t inode, int level)
 		/*
 		 * Dump double indirect blocks.
 		 */
-		if (bread(&disk, fsbtodb(&sblock, ino->di_ib[1]), (void *)&i2blk, 
+		if (bread(&disk, FFS_FSBTODB(&sblock, ino->di_ib[1]), (void *)&i2blk, 
 			(size_t)sblock.fs_bsize) == -1) {
 			err(1, "bread: %s", disk.d_error);
 		}
@@ -412,7 +412,7 @@ dump_whole_ufs1_inode(ino_t inode, int level)
 			sizeof(ufs1_daddr_t))) && (rb>0)); ind2ctr++) {
 			ind2ptr=&((ufs1_daddr_t *)(void *)&i2blk)[ind2ctr];
 
-			if (bread(&disk, fsbtodb(&sblock, *ind2ptr), (void *)&i1blk, 
+			if (bread(&disk, FFS_FSBTODB(&sblock, *ind2ptr), (void *)&i1blk, 
 				(size_t)sblock.fs_bsize) == -1) {
 				err(1, "bread: %s", disk.d_error);
 			}
@@ -430,7 +430,7 @@ dump_whole_ufs1_inode(ino_t inode, int level)
 		/*
 		 * Dump triple indirect blocks.
 		 */
-		if (bread(&disk, fsbtodb(&sblock, ino->di_ib[2]), (void *)&i3blk, 
+		if (bread(&disk, FFS_FSBTODB(&sblock, ino->di_ib[2]), (void *)&i3blk, 
 			(size_t)sblock.fs_bsize) == -1) {
 			err(1, "bread: %s", disk.d_error);
 		}
@@ -447,7 +447,7 @@ dump_whole_ufs1_inode(ino_t inode, int level)
 			sizeof(ufs1_daddr_t)))&&(rb>0)); ind3ctr++) {
 			ind3ptr=&((ufs1_daddr_t *)(void *)&i3blk)[ind3ctr];
 
-			if (bread(&disk, fsbtodb(&sblock, *ind3ptr), (void *)&i2blk, 
+			if (bread(&disk, FFS_FSBTODB(&sblock, *ind3ptr), (void *)&i2blk, 
 				(size_t)sblock.fs_bsize) == -1) {
 				err(1, "bread: %s", disk.d_error);
 			}
@@ -463,7 +463,7 @@ dump_whole_ufs1_inode(ino_t inode, int level)
 			    sizeof(ufs1_daddr_t)))&&(rb>0)); ind2ctr++) {
 				ind2ptr=&((ufs1_daddr_t *)(void *)&i2blk)
 				    [ind2ctr];
-				if (bread(&disk, fsbtodb(&sblock, *ind2ptr),
+				if (bread(&disk, FFS_FSBTODB(&sblock, *ind2ptr),
 				    (void *)&i1blk, (size_t)sblock.fs_bsize)
 				    == -1) {
 					err(1, "bread: %s", disk.d_error);
@@ -534,7 +534,7 @@ dump_whole_ufs2_inode(ino_t inode, int level)
 		/*
 		 * Dump single indirect block.
 		 */
-		if (bread(&disk, fsbtodb(&sblock, ino->di_ib[0]), (void *)&i1blk, 
+		if (bread(&disk, FFS_FSBTODB(&sblock, ino->di_ib[0]), (void *)&i1blk, 
 			(size_t)sblock.fs_bsize) == -1) {
 			err(1, "bread: %s", disk.d_error);
 		}
@@ -547,7 +547,7 @@ dump_whole_ufs2_inode(ino_t inode, int level)
 		/*
 		 * Dump double indirect blocks.
 		 */
-		if (bread(&disk, fsbtodb(&sblock, ino->di_ib[1]), (void *)&i2blk, 
+		if (bread(&disk, FFS_FSBTODB(&sblock, ino->di_ib[1]), (void *)&i2blk, 
 			(size_t)sblock.fs_bsize) == -1) {
 			err(1, "bread: %s", disk.d_error);
 		}
@@ -561,7 +561,7 @@ dump_whole_ufs2_inode(ino_t inode, int level)
 			sizeof(ufs2_daddr_t))) && (rb>0)); ind2ctr++) {
 			ind2ptr = &((ufs2_daddr_t *)(void *)&i2blk)[ind2ctr];
 
-			if (bread(&disk, fsbtodb(&sblock, *ind2ptr), (void *)&i1blk, 
+			if (bread(&disk, FFS_FSBTODB(&sblock, *ind2ptr), (void *)&i1blk, 
 				(size_t)sblock.fs_bsize) == -1) {
 				err(1, "bread: %s", disk.d_error);
 			}
@@ -576,7 +576,7 @@ dump_whole_ufs2_inode(ino_t inode, int level)
 		/*
 		 * Dump triple indirect blocks.
 		 */
-		if (bread(&disk, fsbtodb(&sblock, ino->di_ib[2]), (void *)&i3blk, 
+		if (bread(&disk, FFS_FSBTODB(&sblock, ino->di_ib[2]), (void *)&i3blk, 
 			(size_t)sblock.fs_bsize) == -1) {
 			err(1, "bread: %s", disk.d_error);
 		}
@@ -593,7 +593,7 @@ dump_whole_ufs2_inode(ino_t inode, int level)
 			sizeof(ufs2_daddr_t))) && (rb > 0)); ind3ctr++) {
 			ind3ptr = &((ufs2_daddr_t *)(void *)&i3blk)[ind3ctr];
 
-			if (bread(&disk, fsbtodb(&sblock, *ind3ptr), (void *)&i2blk, 
+			if (bread(&disk, FFS_FSBTODB(&sblock, *ind3ptr), (void *)&i2blk, 
 				(size_t)sblock.fs_bsize) == -1) {
 				err(1, "bread: %s", disk.d_error);
 			}
@@ -608,7 +608,7 @@ dump_whole_ufs2_inode(ino_t inode, int level)
 			for (ind2ctr = 0; ((ind2ctr < howmany(sblock.fs_bsize,
 				sizeof(ufs2_daddr_t))) && (rb > 0)); ind2ctr++) {
 				ind2ptr = &((ufs2_daddr_t *)(void *)&i2blk) [ind2ctr];
-				if (bread(&disk, fsbtodb(&sblock, *ind2ptr), (void *)&i1blk, 
+				if (bread(&disk, FFS_FSBTODB(&sblock, *ind2ptr), (void *)&i1blk, 
 					(size_t)sblock.fs_bsize) == -1) {
 					err(1, "bread: %s", disk.d_error);
 				}

--- a/sbin/fsck_ffs/dir.c
+++ b/sbin/fsck_ffs/dir.c
@@ -216,7 +216,7 @@ dircheck(struct inodesc *idesc, struct direct *dp)
 		goto bad;
 	if (dp->d_ino == 0)
 		return (1);
-	size = DIRSIZ(0, dp);
+	size = UFS_DIRSIZ(0, dp);
 	namlen = dp->d_namlen;
 	type = dp->d_type;
 	if (dp->d_reclen < size ||
@@ -345,9 +345,9 @@ mkentry(struct inodesc *idesc)
 	int newlen, oldlen;
 
 	newent.d_namlen = strlen(idesc->id_name);
-	newlen = DIRSIZ(0, &newent);
+	newlen = UFS_DIRSIZ(0, &newent);
 	if (dirp->d_ino != 0)
-		oldlen = DIRSIZ(0, dirp);
+		oldlen = UFS_DIRSIZ(0, dirp);
 	else
 		oldlen = 0;
 	if (dirp->d_reclen - oldlen < newlen)

--- a/sbin/fsck_ffs/ea.c
+++ b/sbin/fsck_ffs/ea.c
@@ -62,7 +62,7 @@ eascan(struct inodesc *idesc, struct ufs2_dinode *dp)
 	u_int dsize, n;
 	u_char *cp;
 	long blksiz;
-	char dbuf[DIRBLKSIZ];
+	char dbuf[UFS_DIRBLKSIZ];
 
 	printf("Inode %ju extsize %ju\n",
 	   (intmax_t)idesc->id_number, (uintmax_t)dp->di_extsize);

--- a/sbin/fsck_ffs/fsutil.c
+++ b/sbin/fsck_ffs/fsutil.c
@@ -274,7 +274,7 @@ getdatablk(ufs2_daddr_t blkno, long size, int type)
 	struct bufarea *bp;
 
 	TAILQ_FOREACH(bp, &bufhead, b_list)
-		if (bp->b_bno == fsbtodb(&sblock, blkno))
+		if (bp->b_bno == FFS_FSBTODB(&sblock, blkno))
 			goto foundit;
 	TAILQ_FOREACH_REVERSE(bp, &bufhead, buflist, b_list)
 		if ((bp->b_flags & B_INUSE) == 0)
@@ -322,7 +322,7 @@ getblk(struct bufarea *bp, ufs2_daddr_t blk, long size)
 	ufs2_daddr_t dblk;
 	struct timespec start, finish;
 
-	dblk = fsbtodb(&sblock, blk);
+	dblk = FFS_FSBTODB(&sblock, blk);
 	if (bp->b_bno == dblk) {
 		totalreads++;
 	} else {
@@ -364,7 +364,7 @@ flush(int fd, struct bufarea *bp)
 		return;
 	for (i = 0, j = 0; i < sblock.fs_cssize; i += sblock.fs_bsize, j++) {
 		blwrite(fswritefd, (char *)sblock.fs_csp + i,
-		    fsbtodb(&sblock, sblock.fs_csaddr + j * sblock.fs_frag),
+		    FFS_FSBTODB(&sblock, sblock.fs_csaddr + j * sblock.fs_frag),
 		    MIN(sblock.fs_cssize - i, sblock.fs_bsize));
 	}
 }

--- a/sbin/fsck_ffs/gjournal.c
+++ b/sbin/fsck_ffs/gjournal.c
@@ -329,7 +329,7 @@ freeindir(ufs2_daddr_t blk, int level)
 	ufs2_daddr_t *blks;
 	int i;
 
-	if (bread(disk, fsbtodb(fs, blk), (void *)&sblks, (size_t)fs->fs_bsize) == -1)
+	if (bread(disk, FFS_FSBTODB(fs, blk), (void *)&sblks, (size_t)fs->fs_bsize) == -1)
 		err(1, "bread: %s", disk->d_error);
 	blks = (ufs2_daddr_t *)&sblks;
 	for (i = 0; i < NINDIR(fs); i++) {

--- a/sbin/fsck_ffs/main.c
+++ b/sbin/fsck_ffs/main.c
@@ -542,7 +542,7 @@ checkfilesys(char *filesys)
 		 */
 		for (cylno = 0; cylno < sblock.fs_ncg; cylno++)
 			blwrite(fswritefd, (char *)&sblock,
-			    fsbtodb(&sblock, cgsblock(&sblock, cylno)),
+			    FFS_FSBTODB(&sblock, cgsblock(&sblock, cylno)),
 			    SBLOCKSIZE);
 	}
 	if (rerun)

--- a/sbin/fsck_ffs/pass2.c
+++ b/sbin/fsck_ffs/pass2.c
@@ -310,7 +310,7 @@ pass2check(struct inodesc *idesc)
 	proto.d_type = DT_DIR;
 	proto.d_namlen = 1;
 	(void)strcpy(proto.d_name, ".");
-	entrysize = DIRSIZ(0, &proto);
+	entrysize = UFS_DIRSIZ(0, &proto);
 	if (dirp->d_ino != 0 && strcmp(dirp->d_name, "..") != 0) {
 		pfatal("CANNOT FIX, FIRST ENTRY IN DIRECTORY CONTAINS %s\n",
 			dirp->d_name);
@@ -341,9 +341,9 @@ chk1:
 	proto.d_type = DT_DIR;
 	proto.d_namlen = 2;
 	(void)strcpy(proto.d_name, "..");
-	entrysize = DIRSIZ(0, &proto);
+	entrysize = UFS_DIRSIZ(0, &proto);
 	if (idesc->id_entryno == 0) {
-		n = DIRSIZ(0, dirp);
+		n = UFS_DIRSIZ(0, dirp);
 		if (dirp->d_reclen < n + entrysize)
 			goto chk2;
 		proto.d_reclen = dirp->d_reclen - n;

--- a/sbin/fsck_ffs/pass2.c
+++ b/sbin/fsck_ffs/pass2.c
@@ -154,29 +154,29 @@ pass2(void)
 			continue;
 		if (inp->i_isize < MINDIRSIZE) {
 			direrror(inp->i_number, "DIRECTORY TOO SHORT");
-			inp->i_isize = roundup(MINDIRSIZE, DIRBLKSIZ);
+			inp->i_isize = roundup(MINDIRSIZE, UFS_DIRBLKSIZ);
 			if (reply("FIX") == 1) {
 				dp = ginode(inp->i_number);
 				DIP_SET(dp, di_size, inp->i_isize);
 				inodirty();
 			}
-		} else if ((inp->i_isize & (DIRBLKSIZ - 1)) != 0) {
+		} else if ((inp->i_isize & (UFS_DIRBLKSIZ - 1)) != 0) {
 			getpathname(pathbuf, inp->i_number, inp->i_number);
 			if (usedsoftdep)
 				pfatal("%s %s: LENGTH %jd NOT MULTIPLE OF %d",
 					"DIRECTORY", pathbuf,
-					(intmax_t)inp->i_isize, DIRBLKSIZ);
+					(intmax_t)inp->i_isize, UFS_DIRBLKSIZ);
 			else
 				pwarn("%s %s: LENGTH %jd NOT MULTIPLE OF %d",
 					"DIRECTORY", pathbuf,
-					(intmax_t)inp->i_isize, DIRBLKSIZ);
+					(intmax_t)inp->i_isize, UFS_DIRBLKSIZ);
 			if (preen)
 				printf(" (ADJUSTED)\n");
-			inp->i_isize = roundup(inp->i_isize, DIRBLKSIZ);
+			inp->i_isize = roundup(inp->i_isize, UFS_DIRBLKSIZ);
 			if (preen || reply("ADJUST") == 1) {
 				dp = ginode(inp->i_number);
 				DIP_SET(dp, di_size,
-				    roundup(inp->i_isize, DIRBLKSIZ));
+				    roundup(inp->i_isize, UFS_DIRBLKSIZ));
 				inodirty();
 			}
 		}

--- a/sbin/fsck_ffs/pass5.c
+++ b/sbin/fsck_ffs/pass5.c
@@ -588,9 +588,9 @@ clear_blocks(ufs2_daddr_t start, ufs2_daddr_t end)
 	if (debug)
 		printf("Zero frags %jd to %jd\n", start, end);
 	if (Zflag)
-		blzero(fswritefd, fsbtodb(&sblock, start),
+		blzero(fswritefd, FFS_FSBTODB(&sblock, start),
 		    ffs_lfragtosize(&sblock, end - start + 1));
 	if (Eflag)
-		blerase(fswritefd, fsbtodb(&sblock, start),
+		blerase(fswritefd, FFS_FSBTODB(&sblock, start),
 		    ffs_lfragtosize(&sblock, end - start + 1));
 }

--- a/sbin/fsck_ffs/setup.c
+++ b/sbin/fsck_ffs/setup.c
@@ -181,7 +181,7 @@ setup(char *dev)
 		if (reply("LOOK FOR ALTERNATE SUPERBLOCKS") == 0)
 			return (0);
 		for (cg = 0; cg < proto.fs_ncg; cg++) {
-			bflag = fsbtodb(&proto, cgsblock(&proto, cg));
+			bflag = FFS_FSBTODB(&proto, cgsblock(&proto, cg));
 			if (readsb(0) != 0)
 				break;
 		}
@@ -248,7 +248,7 @@ setup(char *dev)
 		size = MIN(sblock.fs_cssize - i, sblock.fs_bsize);
 		readcnt[sblk.b_type]++;
 		if (blread(fsreadfd, (char *)sblock.fs_csp + i,
-		    fsbtodb(&sblock, sblock.fs_csaddr + j * sblock.fs_frag),
+		    FFS_FSBTODB(&sblock, sblock.fs_csaddr + j * sblock.fs_frag),
 		    size) != 0 && !asked) {
 			pfatal("BAD SUMMARY INFORMATION");
 			if (reply("CONTINUE") == 0) {
@@ -356,11 +356,11 @@ readsb(int listerr)
 	}
 	/*
 	 * Compute block size that the file system is based on,
-	 * according to fsbtodb, and adjust superblock block number
+	 * according to FFS_FSBTODB, and adjust superblock block number
 	 * so we can tell if this is an alternate later.
 	 */
 	super *= dev_bsize;
-	dev_bsize = sblock.fs_fsize / fsbtodb(&sblock, 1);
+	dev_bsize = sblock.fs_fsize / FFS_FSBTODB(&sblock, 1);
 	sblk.b_bno = super / dev_bsize;
 	sblk.b_size = SBLOCKSIZE;
 	if (bflag)

--- a/sbin/fsck_ffs/suj.c
+++ b/sbin/fsck_ffs/suj.c
@@ -53,7 +53,7 @@ __FBSDID("$FreeBSD$");
 
 #include "fsck.h"
 
-#define	DOTDOT_OFFSET	DIRECTSIZ(1)
+#define	DOTDOT_OFFSET	UFS_DIRECTSIZ(1)
 #define	SUJ_HASHSIZE	2048
 #define	SUJ_HASHMASK	(SUJ_HASHSIZE - 1)
 #define	SUJ_HASH(x)	((x * 2654435761) & SUJ_HASHMASK)
@@ -891,7 +891,7 @@ ino_isat(ino_t parent, off_t diroff, ino_t child, int *mode, int *isdot)
 	lbn = ffs_lblkno(fs, diroff);
 	doff = ffs_blkoff(fs, diroff);
 	blksize = ffs_sblksize(fs, DIP(dip, di_size), lbn);
-	if (diroff + DIRECTSIZ(1) > DIP(dip, di_size) || doff >= blksize) {
+	if (diroff + UFS_DIRECTSIZ(1) > DIP(dip, di_size) || doff >= blksize) {
 		if (debug)
 			printf("ino %ju absent from %ju due to offset %jd"
 			    " exceeding size %jd\n",

--- a/sbin/fsck_ffs/suj.c
+++ b/sbin/fsck_ffs/suj.c
@@ -911,7 +911,7 @@ ino_isat(ino_t parent, off_t diroff, ino_t child, int *mode, int *isdot)
 	 * certain we hit a valid record and not some junk in the middle
 	 * of a file name.  Stop when we reach or pass the expected offset.
 	 */
-	dpoff = rounddown(doff, DIRBLKSIZ);
+	dpoff = rounddown(doff, UFS_DIRBLKSIZ);
 	do {
 		dp = (struct direct *)&block[dpoff];
 		if (dpoff == doff)

--- a/sbin/fsdb/fsdb.c
+++ b/sbin/fsdb/fsdb.c
@@ -454,13 +454,13 @@ CMDFUNCSTART(findblk)
 	if (wantedblk64 == NULL)
 	    err(1, "malloc");
 	for (i = 1; i < argc; i++)
-	    wantedblk64[i - 1] = dbtofsb(&sblock, strtoull(argv[i], NULL, 0));
+	    wantedblk64[i - 1] = FFS_DBTOFSB(&sblock, strtoull(argv[i], NULL, 0));
     } else {
 	wantedblk32 = calloc(wantedblksize, sizeof(uint32_t));
 	if (wantedblk32 == NULL)
 	    err(1, "malloc");
 	for (i = 1; i < argc; i++)
-	    wantedblk32[i - 1] = dbtofsb(&sblock, strtoull(argv[i], NULL, 0));
+	    wantedblk32[i - 1] = FFS_DBTOFSB(&sblock, strtoull(argv[i], NULL, 0));
     }
     findblk_numtofind = wantedblksize;
     /*
@@ -499,7 +499,7 @@ CMDFUNCSTART(findblk)
 		compare_blk64(wantedblk64, ino_to_fsba(&sblock, inum)) :
 		compare_blk32(wantedblk32, ino_to_fsba(&sblock, inum))) {
 		printf("block %llu: inode block (%ju-%ju)\n",
-		    (unsigned long long)fsbtodb(&sblock,
+		    (unsigned long long)FFS_FSBTODB(&sblock,
 			ino_to_fsba(&sblock, inum)),
 		    (uintmax_t)(inum / FFS_INOPB(&sblock)) * FFS_INOPB(&sblock),
 		    (uintmax_t)(inum / FFS_INOPB(&sblock) + 1) * FFS_INOPB(&sblock));
@@ -599,7 +599,7 @@ founddatablk(uint64_t blk)
 {
 
     printf("%llu: data block of inode %ju\n",
-	(unsigned long long)fsbtodb(&sblock, blk), (uintmax_t)curinum);
+	(unsigned long long)FFS_FSBTODB(&sblock, blk), (uintmax_t)curinum);
     findblk_numtofind--;
     if (findblk_numtofind == 0)
 	return 1;
@@ -628,7 +628,7 @@ find_indirblks32(uint32_t blk, int ind_level, uint32_t *wantedblk)
     uint32_t idblk[MAXNINDIR];
     int i;
 
-    blread(fsreadfd, (char *)idblk, fsbtodb(&sblock, blk), (int)sblock.fs_bsize);
+    blread(fsreadfd, (char *)idblk, FFS_FSBTODB(&sblock, blk), (int)sblock.fs_bsize);
     if (ind_level <= 0) {
 	if (find_blks32(idblk, sblock.fs_bsize / sizeof(uint32_t), wantedblk))
 	    return 1;
@@ -670,7 +670,7 @@ find_indirblks64(uint64_t blk, int ind_level, uint64_t *wantedblk)
     uint64_t idblk[MAXNINDIR];
     int i;
 
-    blread(fsreadfd, (char *)idblk, fsbtodb(&sblock, blk), (int)sblock.fs_bsize);
+    blread(fsreadfd, (char *)idblk, FFS_FSBTODB(&sblock, blk), (int)sblock.fs_bsize);
     if (ind_level <= 0) {
 	if (find_blks64(idblk, sblock.fs_bsize / sizeof(uint64_t), wantedblk))
 	    return 1;

--- a/sbin/fsdb/fsdb.c
+++ b/sbin/fsdb/fsdb.c
@@ -835,7 +835,7 @@ chnamefunc(struct inodesc *idesc)
 	if (slotcount++ == desired) {
 	    /* will name fit? */
 	    testdir.d_namlen = strlen(idesc->id_name);
-	    if (DIRSIZ(NEWDIRFMT, &testdir) <= dirp->d_reclen) {
+	    if (UFS_DIRSIZ(UFS_NEWDIRFMT, &testdir) <= dirp->d_reclen) {
 		dirp->d_namlen = testdir.d_namlen;
 		strcpy(dirp->d_name, idesc->id_name);
 		return STOP|ALTERED|FOUND;

--- a/sbin/fsirand/fsirand.c
+++ b/sbin/fsirand/fsirand.c
@@ -168,7 +168,7 @@ fsirand(char *device)
 	/* Make sure backup superblocks are sane. */
 	sblock = (struct fs *)&sbuftmp;
 	for (cg = 0; cg < (int)sblock->fs_ncg; cg++) {
-		dblk = fsbtodb(sblock, cgsblock(sblock, cg));
+		dblk = FFS_FSBTODB(sblock, cgsblock(sblock, cg));
 		if (lseek(devfd, (off_t)dblk * bsize, SEEK_SET) < 0) {
 			warn("can't seek to %jd", (intmax_t)dblk * bsize);
 			return (1);
@@ -231,7 +231,7 @@ fsirand(char *device)
 	for (cg = 0, inumber = 0; cg < (int)sblock->fs_ncg; cg++) {
 		/* Update superblock if appropriate */
 		if (!printonly) {
-			dblk = fsbtodb(sblock, cgsblock(sblock, cg));
+			dblk = FFS_FSBTODB(sblock, cgsblock(sblock, cg));
 			if (lseek(devfd, (off_t)dblk * bsize, SEEK_SET) < 0) {
 				warn("can't seek to %jd",
 				    (intmax_t)dblk * bsize);
@@ -246,7 +246,7 @@ fsirand(char *device)
 		}
 
 		/* Read in inodes, then print or randomize generation nums */
-		dblk = fsbtodb(sblock, ino_to_fsba(sblock, inumber));
+		dblk = FFS_FSBTODB(sblock, ino_to_fsba(sblock, inumber));
 		if (lseek(devfd, (off_t)dblk * bsize, SEEK_SET) < 0) {
 			warn("can't seek to %jd", (intmax_t)dblk * bsize);
 			return (1);

--- a/sbin/geom/class/journal/geom_journal_ufs.c
+++ b/sbin/geom/class/journal/geom_journal_ufs.c
@@ -73,6 +73,6 @@ g_journal_ufs_using_last_sector(const char *prov)
 	/* Provider size in 512 bytes blocks. */
 	psize = g_get_mediasize(prov) / DEV_BSIZE;
 	/* File system size in 512 bytes blocks. */
-	fssize = fsbtodb(fs, fs->fs_size);
+	fssize = FFS_FSBTODB(fs, fs->fs_size);
 	return (psize <= fssize);
 }

--- a/sbin/newfs/mkfs.c
+++ b/sbin/newfs/mkfs.c
@@ -921,8 +921,8 @@ makedir(struct direct *protodir, int entries)
 	char *cp;
 	int i, spcleft;
 
-	spcleft = DIRBLKSIZ;
-	memset(iobuf, 0, DIRBLKSIZ);
+	spcleft = UFS_DIRBLKSIZ;
+	memset(iobuf, 0, UFS_DIRBLKSIZ);
 	for (cp = iobuf, i = 0; i < entries - 1; i++) {
 		protodir[i].d_reclen = DIRSIZ(0, &protodir[i]);
 		memmove(cp, &protodir[i], protodir[i].d_reclen);
@@ -931,7 +931,7 @@ makedir(struct direct *protodir, int entries)
 	}
 	protodir[i].d_reclen = spcleft;
 	memmove(cp, &protodir[i], DIRSIZ(0, &protodir[i]));
-	return (DIRBLKSIZ);
+	return (UFS_DIRBLKSIZ);
 }
 
 /*

--- a/sbin/newfs/mkfs.c
+++ b/sbin/newfs/mkfs.c
@@ -924,13 +924,13 @@ makedir(struct direct *protodir, int entries)
 	spcleft = UFS_DIRBLKSIZ;
 	memset(iobuf, 0, UFS_DIRBLKSIZ);
 	for (cp = iobuf, i = 0; i < entries - 1; i++) {
-		protodir[i].d_reclen = DIRSIZ(0, &protodir[i]);
+		protodir[i].d_reclen = UFS_DIRSIZ(0, &protodir[i]);
 		memmove(cp, &protodir[i], protodir[i].d_reclen);
 		cp += protodir[i].d_reclen;
 		spcleft -= protodir[i].d_reclen;
 	}
 	protodir[i].d_reclen = spcleft;
-	memmove(cp, &protodir[i], DIRSIZ(0, &protodir[i]));
+	memmove(cp, &protodir[i], UFS_DIRSIZ(0, &protodir[i]));
 	return (UFS_DIRBLKSIZ);
 }
 

--- a/sbin/quotacheck/quotacheck.c
+++ b/sbin/quotacheck/quotacheck.c
@@ -335,12 +335,12 @@ chkquota(char *specname, struct quotafile *qfu, struct quotafile *qfg)
 		warn("Cannot find file system superblock");
 		return (1);
 	}
-	dev_bsize = sblock.fs_fsize / fsbtodb(&sblock, 1);
+	dev_bsize = sblock.fs_fsize / FFS_FSBTODB(&sblock, 1);
 	maxino = sblock.fs_ncg * sblock.fs_ipg;
 	for (cg = 0; cg < sblock.fs_ncg; cg++) {
 		ino = cg * sblock.fs_ipg;
 		setinodebuf(ino);
-		bread(fsbtodb(&sblock, cgtod(&sblock, cg)), (char *)(&cgblk),
+		bread(FFS_FSBTODB(&sblock, cgtod(&sblock, cg)), (char *)(&cgblk),
 		    sblock.fs_cgsize);
 		if (sblock.fs_magic == FS_UFS2_MAGIC)
 			inosused = cgblk.cg_initediblk;
@@ -607,7 +607,7 @@ getnextinode(ino_t inumber)
 		    (uintmax_t)inumber);
 	if (inumber >= lastinum) {
 		readcnt++;
-		dblk = fsbtodb(&sblock, ino_to_fsba(&sblock, lastinum));
+		dblk = FFS_FSBTODB(&sblock, ino_to_fsba(&sblock, lastinum));
 		if (readcnt % readpercg == 0) {
 			size = partialsize;
 			lastinum += partialcnt;

--- a/sbin/restore/dirs.c
+++ b/sbin/restore/dirs.c
@@ -172,7 +172,7 @@ extractdirs(int genmode)
 	nulldir.d_type = DT_DIR;
 	nulldir.d_namlen = 1;
 	(void) strcpy(nulldir.d_name, "/");
-	nulldir.d_reclen = DIRSIZ(0, &nulldir);
+	nulldir.d_reclen = UFS_DIRSIZ(0, &nulldir);
 	for (;;) {
 		curfile.name = "<directory file - name unknown>";
 		curfile.action = USING;
@@ -346,7 +346,7 @@ putdir(char *buf, size_t size)
 		i = DIRBLKSIZ - (loc & (DIRBLKSIZ - 1));
 		if ((dp->d_reclen & 0x3) != 0 ||
 		    dp->d_reclen > i ||
-		    dp->d_reclen < DIRSIZ(0, dp)
+		    dp->d_reclen < UFS_DIRSIZ(0, dp)
 #if NAME_MAX < 255
 		    || dp->d_namlen > NAME_MAX
 #endif
@@ -355,10 +355,10 @@ putdir(char *buf, size_t size)
 			if ((dp->d_reclen & 0x3) != 0)
 				vprintf(stdout,
 				   "reclen not multiple of 4 ");
-			if (dp->d_reclen < DIRSIZ(0, dp))
+			if (dp->d_reclen < UFS_DIRSIZ(0, dp))
 				vprintf(stdout,
-				   "reclen less than DIRSIZ (%u < %zu) ",
-				   dp->d_reclen, DIRSIZ(0, dp));
+				   "reclen less than UFS_DIRSIZ (%u < %zu) ",
+				   dp->d_reclen, UFS_DIRSIZ(0, dp));
 #if NAME_MAX < 255
 			if (dp->d_namlen > NAME_MAX)
 				vprintf(stdout,
@@ -389,7 +389,7 @@ long prev = 0;
 static void
 putent(struct direct *dp)
 {
-	dp->d_reclen = DIRSIZ(0, dp);
+	dp->d_reclen = UFS_DIRSIZ(0, dp);
 	if (dirloc + dp->d_reclen > DIRBLKSIZ) {
 		((struct direct *)(dirbuf + prev))->d_reclen =
 		    DIRBLKSIZ - prev;

--- a/sbin/tunefs/tunefs.c
+++ b/sbin/tunefs/tunefs.c
@@ -724,17 +724,17 @@ dir_clear_block(const char *block, off_t off)
 {
 	struct direct *dp;
 
-	for (; off < sblock.fs_bsize; off += DIRBLKSIZ) {
+	for (; off < sblock.fs_bsize; off += UFS_DIRBLKSIZ) {
 		dp = (struct direct *)&block[off];
 		dp->d_ino = 0;
-		dp->d_reclen = DIRBLKSIZ;
+		dp->d_reclen = UFS_DIRBLKSIZ;
 		dp->d_type = DT_UNKNOWN;
 	}
 }
 
 /*
  * Insert the journal at inode 'ino' into directory blk 'blk' at the first
- * free offset of 'off'.  DIRBLKSIZ blocks after off are initialized as
+ * free offset of 'off'.  UFS_DIRBLKSIZ blocks after off are initialized as
  * empty.
  */
 static int
@@ -750,11 +750,11 @@ dir_insert(ufs2_daddr_t blk, off_t off, ino_t ino)
 	bzero(&block[off], sblock.fs_bsize - off);
 	dp = (struct direct *)&block[off];
 	dp->d_ino = ino;
-	dp->d_reclen = DIRBLKSIZ;
+	dp->d_reclen = UFS_DIRBLKSIZ;
 	dp->d_type = DT_REG;
 	dp->d_namlen = strlen(SUJ_FILE);
 	bcopy(SUJ_FILE, &dp->d_name, strlen(SUJ_FILE));
-	dir_clear_block(block, off + DIRBLKSIZ);
+	dir_clear_block(block, off + UFS_DIRBLKSIZ);
 	if (bwrite(&disk, FFS_FSBTODB(&sblock, blk), block, sblock.fs_bsize) <= 0) {
 		warn("Failed to write dir block");
 		return (-1);

--- a/sbin/tunefs/tunefs.c
+++ b/sbin/tunefs/tunefs.c
@@ -632,7 +632,7 @@ journal_balloc(void)
 		warnx("Failed to find sufficient free blocks for the journal");
 		return -1;
 	}
-	if (bwrite(&disk, fsbtodb(&sblock, blk), clrbuf,
+	if (bwrite(&disk, FFS_FSBTODB(&sblock, blk), clrbuf,
 	    sblock.fs_bsize) <= 0) {
 		warn("Failed to initialize new block");
 		return -1;
@@ -650,7 +650,7 @@ dir_search(ufs2_daddr_t blk, int bytes)
 	struct direct *dp;
 	int off;
 
-	if (bread(&disk, fsbtodb(&sblock, blk), block, bytes) <= 0) {
+	if (bread(&disk, FFS_FSBTODB(&sblock, blk), block, bytes) <= 0) {
 		warn("Failed to read dir block");
 		return (-1);
 	}
@@ -743,7 +743,7 @@ dir_insert(ufs2_daddr_t blk, off_t off, ino_t ino)
 	struct direct *dp;
 	char block[MAXBSIZE];
 
-	if (bread(&disk, fsbtodb(&sblock, blk), block, sblock.fs_bsize) <= 0) {
+	if (bread(&disk, FFS_FSBTODB(&sblock, blk), block, sblock.fs_bsize) <= 0) {
 		warn("Failed to read dir block");
 		return (-1);
 	}
@@ -755,7 +755,7 @@ dir_insert(ufs2_daddr_t blk, off_t off, ino_t ino)
 	dp->d_namlen = strlen(SUJ_FILE);
 	bcopy(SUJ_FILE, &dp->d_name, strlen(SUJ_FILE));
 	dir_clear_block(block, off + DIRBLKSIZ);
-	if (bwrite(&disk, fsbtodb(&sblock, blk), block, sblock.fs_bsize) <= 0) {
+	if (bwrite(&disk, FFS_FSBTODB(&sblock, blk), block, sblock.fs_bsize) <= 0) {
 		warn("Failed to write dir block");
 		return (-1);
 	}
@@ -771,13 +771,13 @@ dir_extend(ufs2_daddr_t blk, ufs2_daddr_t nblk, off_t size, ino_t ino)
 {
 	char block[MAXBSIZE];
 
-	if (bread(&disk, fsbtodb(&sblock, blk), block,
+	if (bread(&disk, FFS_FSBTODB(&sblock, blk), block,
 	    roundup(size, sblock.fs_fsize)) <= 0) {
 		warn("Failed to read dir block");
 		return (-1);
 	}
 	dir_clear_block(block, size);
-	if (bwrite(&disk, fsbtodb(&sblock, nblk), block, sblock.fs_bsize)
+	if (bwrite(&disk, FFS_FSBTODB(&sblock, nblk), block, sblock.fs_bsize)
 	    <= 0) {
 		warn("Failed to write dir block");
 		return (-1);
@@ -900,7 +900,7 @@ indir_fill(ufs2_daddr_t blk, int level, int *resid)
 		} else 
 			(*resid)--;
 	}
-	if (bwrite(&disk, fsbtodb(&sblock, blk), indirbuf,
+	if (bwrite(&disk, FFS_FSBTODB(&sblock, blk), indirbuf,
 	    sblock.fs_bsize) <= 0) {
 		warn("Failed to write indirect");
 		return (-1);

--- a/sys/boot/common/ufsread.c
+++ b/sys/boot/common/ufsread.c
@@ -71,10 +71,10 @@ typedef	uint32_t	ufs_ino_t;
 #define INDIRPERVBLK(fs) (NINDIR(fs) / ((fs)->fs_bsize >> VBLKSHIFT))
 #define IPERVBLK(fs)	(FFS_INOPB(fs) / ((fs)->fs_bsize >> VBLKSHIFT))
 #define INO_TO_VBA(fs, ipervblk, x) \
-    (fsbtodb(fs, cgimin(fs, ino_to_cg(fs, x))) + \
+    (FFS_FSBTODB(fs, cgimin(fs, ino_to_cg(fs, x))) + \
     (((x) % (fs)->fs_ipg) / (ipervblk) * DBPERVBLK))
 #define INO_TO_VBO(ipervblk, x) ((x) % ipervblk)
-#define FS_TO_VBA(fs, fsb, off) (fsbtodb(fs, fsb) + \
+#define FS_TO_VBA(fs, fsb, off) (FFS_FSBTODB(fs, fsb) + \
     ((off) / VBLKSIZE) * DBPERVBLK)
 #define FS_TO_VBO(fs, fsb, off) ((off) & VBLKMASK)
 
@@ -267,7 +267,7 @@ fsread_size(ufs_ino_t inode, void *buf, size_t nbyte, size_t *fsizep)
 			n = INDIRPERVBLK(&fs);
 			addr2 = DIP(di_ib[0]);
 			u = (u_int)(lbn - UFS_NDADDR) / n * DBPERVBLK;
-			vbaddr = fsbtodb(&fs, addr2) + u;
+			vbaddr = FFS_FSBTODB(&fs, addr2) + u;
 			if (indmap != vbaddr) {
 				if (dskread(indbuf, vbaddr, DBPERVBLK))
 					return -1;
@@ -292,7 +292,7 @@ fsread_size(ufs_ino_t inode, void *buf, size_t nbyte, size_t *fsizep)
 #endif
 		} else
 			return -1;
-		vbaddr = fsbtodb(&fs, addr2) + (off >> VBLKSHIFT) * DBPERVBLK;
+		vbaddr = FFS_FSBTODB(&fs, addr2) + (off >> VBLKSHIFT) * DBPERVBLK;
 		vboff = off & VBLKMASK;
 		n = ffs_sblksize(&fs, (off_t)size, lbn) - (off & ~VBLKMASK);
 		if (n > VBLKSIZE)

--- a/sys/fs/ext2fs/ext2_lookup.c
+++ b/sys/fs/ext2fs/ext2_lookup.c
@@ -53,8 +53,6 @@
 #include <sys/dirent.h>
 #include <sys/sysctl.h>
 
-#include <ufs/ufs/dir.h>
-
 #include <fs/ext2fs/inode.h>
 #include <fs/ext2fs/ext2_mount.h>
 #include <fs/ext2fs/ext2fs.h>
@@ -70,13 +68,6 @@ static int dirchk = 0;
 
 static SYSCTL_NODE(_vfs, OID_AUTO, e2fs, CTLFLAG_RD, 0, "EXT2FS filesystem");
 SYSCTL_INT(_vfs_e2fs, OID_AUTO, dircheck, CTLFLAG_RW, &dirchk, 0, "");
-
-/*
-   DIRBLKSIZE in ffs is DEV_BSIZE (in most cases 512)
-   while it is the native blocksize in ext2fs - thus, a #define
-   is no longer appropriate
-*/
-#undef  DIRBLKSIZ
 
 static u_char ext2_ft_to_dt[] = {
 	DT_UNKNOWN,		/* EXT2_FT_UNKNOWN */
@@ -143,6 +134,10 @@ ext2_readdir(struct vop_readdir_args *ap)
 	size_t readcnt, skipcnt;
 	ssize_t startresid;
 	int ncookies;
+	/* 
+	 * DIRBLKSIZ in ffs is DEV_BSIZE (in most cases 512) 
+	 * while it is the native blocksize in ext2fs 
+	 */
 	int DIRBLKSIZ = VTOI(ap->a_vp)->i_e2fs->e2fs_bsize;
 	int error;
 

--- a/sys/ufs/ffs/ffs_alloc.c
+++ b/sys/ufs/ffs/ffs_alloc.c
@@ -305,7 +305,7 @@ retry:
 	if (bp->b_blkno == bp->b_lblkno) {
 		if (lbprev >= UFS_NDADDR)
 			panic("ffs_realloccg: lbprev out of range");
-		bp->b_blkno = fsbtodb(fs, bprev);
+		bp->b_blkno = FFS_FSBTODB(fs, bprev);
 	}
 
 #ifdef QUOTA
@@ -323,7 +323,7 @@ retry:
 	UFS_LOCK(ump);
 	bno = ffs_fragextend(ip, cg, bprev, osize, nsize);
 	if (bno) {
-		if (bp->b_blkno != fsbtodb(fs, bno))
+		if (bp->b_blkno != FFS_FSBTODB(fs, bno))
 			panic("ffs_realloccg: bad blockno");
 		delta = btodb(nsize - osize);
 		DIP_SET(ip, i_blocks, DIP(ip, i_blocks) + delta);
@@ -389,7 +389,7 @@ retry:
 	}
 	bno = ffs_hashalloc(ip, cg, bpref, request, nsize, ffs_alloccg);
 	if (bno > 0) {
-		bp->b_blkno = fsbtodb(fs, bno);
+		bp->b_blkno = FFS_FSBTODB(fs, bno);
 		if (!DOINGSOFTDEP(vp))
 			ffs_blkfree(ump, fs, ump->um_devvp, bprev, (long)osize,
 			    ip->i_number, vp->v_type, NULL);
@@ -546,13 +546,13 @@ ffs_reallocblks_ufs1(ap)
 #ifdef INVARIANTS
 	for (i = 0; i < len; i++)
 		if (!ffs_checkblk(ip,
-		   dbtofsb(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
+		   FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
 			panic("ffs_reallocblks: unallocated block 1");
 	for (i = 1; i < len; i++)
 		if (buflist->bs_children[i]->b_lblkno != start_lbn + i)
 			panic("ffs_reallocblks: non-logical cluster");
 	blkno = buflist->bs_children[0]->b_blkno;
-	ssize = fsbtodb(fs, fs->fs_frag);
+	ssize = FFS_FSBTODB(fs, fs->fs_frag);
 	for (i = 1; i < len - 1; i++)
 		if (buflist->bs_children[i]->b_blkno != blkno + (i * ssize))
 			panic("ffs_reallocblks: non-physical cluster %d", i);
@@ -574,8 +574,8 @@ ffs_reallocblks_ufs1(ap)
 	 * the filesystem has decided to move and do not force it back to
 	 * the previous cylinder group.
 	 */
-	if (dtog(fs, dbtofsb(fs, buflist->bs_children[0]->b_blkno)) !=
-	    dtog(fs, dbtofsb(fs, buflist->bs_children[len - 1]->b_blkno)))
+	if (dtog(fs, FFS_DBTOFSB(fs, buflist->bs_children[0]->b_blkno)) !=
+	    dtog(fs, FFS_DBTOFSB(fs, buflist->bs_children[len - 1]->b_blkno)))
 		return (ENOSPC);
 	if (ufs_getlbns(vp, start_lbn, start_ap, &start_lvl) ||
 	    ufs_getlbns(vp, end_lbn, end_ap, &end_lvl))
@@ -667,9 +667,9 @@ ffs_reallocblks_ufs1(ap)
 		}
 #ifdef INVARIANTS
 		if (!ffs_checkblk(ip,
-		   dbtofsb(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
+		   FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
 			panic("ffs_reallocblks: unallocated block 2");
-		if (dbtofsb(fs, buflist->bs_children[i]->b_blkno) != *bap)
+		if (FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno) != *bap)
 			panic("ffs_reallocblks: alloc mismatch");
 #endif
 #ifdef DEBUG
@@ -728,12 +728,12 @@ ffs_reallocblks_ufs1(ap)
 	for (blkno = newblk, i = 0; i < len; i++, blkno += fs->fs_frag) {
 		if (!DOINGSOFTDEP(vp))
 			ffs_blkfree(ump, fs, ump->um_devvp,
-			    dbtofsb(fs, buflist->bs_children[i]->b_blkno),
+			    FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno),
 			    fs->fs_bsize, ip->i_number, vp->v_type, NULL);
-		buflist->bs_children[i]->b_blkno = fsbtodb(fs, blkno);
+		buflist->bs_children[i]->b_blkno = FFS_FSBTODB(fs, blkno);
 #ifdef INVARIANTS
 		if (!ffs_checkblk(ip,
-		   dbtofsb(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
+		   FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
 			panic("ffs_reallocblks: unallocated block 3");
 #endif
 #ifdef DEBUG
@@ -795,13 +795,13 @@ ffs_reallocblks_ufs2(ap)
 #ifdef INVARIANTS
 	for (i = 0; i < len; i++)
 		if (!ffs_checkblk(ip,
-		   dbtofsb(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
+		   FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
 			panic("ffs_reallocblks: unallocated block 1");
 	for (i = 1; i < len; i++)
 		if (buflist->bs_children[i]->b_lblkno != start_lbn + i)
 			panic("ffs_reallocblks: non-logical cluster");
 	blkno = buflist->bs_children[0]->b_blkno;
-	ssize = fsbtodb(fs, fs->fs_frag);
+	ssize = FFS_FSBTODB(fs, fs->fs_frag);
 	for (i = 1; i < len - 1; i++)
 		if (buflist->bs_children[i]->b_blkno != blkno + (i * ssize))
 			panic("ffs_reallocblks: non-physical cluster %d", i);
@@ -823,8 +823,8 @@ ffs_reallocblks_ufs2(ap)
 	 * the filesystem has decided to move and do not force it back to
 	 * the previous cylinder group.
 	 */
-	if (dtog(fs, dbtofsb(fs, buflist->bs_children[0]->b_blkno)) !=
-	    dtog(fs, dbtofsb(fs, buflist->bs_children[len - 1]->b_blkno)))
+	if (dtog(fs, FFS_DBTOFSB(fs, buflist->bs_children[0]->b_blkno)) !=
+	    dtog(fs, FFS_DBTOFSB(fs, buflist->bs_children[len - 1]->b_blkno)))
 		return (ENOSPC);
 	if (ufs_getlbns(vp, start_lbn, start_ap, &start_lvl) ||
 	    ufs_getlbns(vp, end_lbn, end_ap, &end_lvl))
@@ -915,9 +915,9 @@ ffs_reallocblks_ufs2(ap)
 		}
 #ifdef INVARIANTS
 		if (!ffs_checkblk(ip,
-		   dbtofsb(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
+		   FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
 			panic("ffs_reallocblks: unallocated block 2");
-		if (dbtofsb(fs, buflist->bs_children[i]->b_blkno) != *bap)
+		if (FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno) != *bap)
 			panic("ffs_reallocblks: alloc mismatch");
 #endif
 #ifdef DEBUG
@@ -976,12 +976,12 @@ ffs_reallocblks_ufs2(ap)
 	for (blkno = newblk, i = 0; i < len; i++, blkno += fs->fs_frag) {
 		if (!DOINGSOFTDEP(vp))
 			ffs_blkfree(ump, fs, ump->um_devvp,
-			    dbtofsb(fs, buflist->bs_children[i]->b_blkno),
+			    FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno),
 			    fs->fs_bsize, ip->i_number, vp->v_type, NULL);
-		buflist->bs_children[i]->b_blkno = fsbtodb(fs, blkno);
+		buflist->bs_children[i]->b_blkno = FFS_FSBTODB(fs, blkno);
 #ifdef INVARIANTS
 		if (!ffs_checkblk(ip,
-		   dbtofsb(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
+		   FFS_DBTOFSB(fs, buflist->bs_children[i]->b_blkno), fs->fs_bsize))
 			panic("ffs_reallocblks: unallocated block 3");
 #endif
 #ifdef DEBUG
@@ -1602,7 +1602,7 @@ ffs_fragextend(ip, cg, bprev, osize, nsize)
 		return (0);
 	}
 	UFS_UNLOCK(ump);
-	error = bread(ump->um_devvp, fsbtodb(fs, cgtod(fs, cg)),
+	error = bread(ump->um_devvp, FFS_FSBTODB(fs, cgtod(fs, cg)),
 	    (int)fs->fs_cgsize, NOCRED, &bp);
 	if (error)
 		goto fail;
@@ -1680,7 +1680,7 @@ ffs_alloccg(ip, cg, bpref, size, rsize)
 	if (fs->fs_cs(fs, cg).cs_nbfree == 0 && size == fs->fs_bsize)
 		return (0);
 	UFS_UNLOCK(ump);
-	error = bread(ump->um_devvp, fsbtodb(fs, cgtod(fs, cg)),
+	error = bread(ump->um_devvp, FFS_FSBTODB(fs, cgtod(fs, cg)),
 	    (int)fs->fs_cgsize, NOCRED, &bp);
 	if (error)
 		goto fail;
@@ -1868,7 +1868,7 @@ ffs_clusteralloc(ip, cg, bpref, len)
 	if (fs->fs_maxcluster[cg] < len)
 		return (0);
 	UFS_UNLOCK(ump);
-	if (bread(ump->um_devvp, fsbtodb(fs, cgtod(fs, cg)), (int)fs->fs_cgsize,
+	if (bread(ump->um_devvp, FFS_FSBTODB(fs, cgtod(fs, cg)), (int)fs->fs_cgsize,
 	    NOCRED, &bp))
 		goto fail_lock;
 	cgp = (struct cg *)bp->b_data;
@@ -1968,7 +1968,7 @@ getinobuf(struct inode *ip, u_int cg, u_int32_t cginoblk, int gbflags)
 	struct fs *fs;
 
 	fs = ITOFS(ip);
-	return (getblk(ITODEVVP(ip), fsbtodb(fs, ino_to_fsba(fs,
+	return (getblk(ITODEVVP(ip), FFS_FSBTODB(fs, ino_to_fsba(fs,
 	    cg * fs->fs_ipg + cginoblk)), (int)fs->fs_bsize, 0, 0,
 	    gbflags));
 }
@@ -2005,7 +2005,7 @@ check_nifree:
 	if (fs->fs_cs(fs, cg).cs_nifree == 0)
 		return (0);
 	UFS_UNLOCK(ump);
-	error = bread(ump->um_devvp, fsbtodb(fs, cgtod(fs, cg)),
+	error = bread(ump->um_devvp, FFS_FSBTODB(fs, cgtod(fs, cg)),
 		(int)fs->fs_cgsize, NOCRED, &bp);
 	if (error) {
 		brelse(bp);
@@ -2103,7 +2103,7 @@ gotit:
 		 * to it, then leave it unchanged as the other thread
 		 * has already set it correctly.
 		 */
-		error = bread(ump->um_devvp, fsbtodb(fs, cgtod(fs, cg)),
+		error = bread(ump->um_devvp, FFS_FSBTODB(fs, cgtod(fs, cg)),
 		    (int)fs->fs_cgsize, NOCRED, &bp);
 		UFS_LOCK(ump);
 		ACTIVECLEAR(fs, cg);
@@ -2174,7 +2174,7 @@ ffs_blkfree_cg(ump, fs, devvp, bno, size, inum, dephd)
 	} else if (devvp->v_type == VCHR) {
 		/* devvp is a normal disk device */
 		dev = devvp->v_rdev;
-		cgblkno = fsbtodb(fs, cgtod(fs, cg));
+		cgblkno = FFS_FSBTODB(fs, cgtod(fs, cg));
 		ASSERT_VOP_LOCKED(devvp, "ffs_blkfree_cg");
 	} else
 		return;
@@ -2372,7 +2372,7 @@ ffs_blkfree(ump, fs, devvp, bno, size, inum, vtype, dephd)
 
 	bip = g_alloc_bio();
 	bip->bio_cmd = BIO_DELETE;
-	bip->bio_offset = dbtob(fsbtodb(fs, bno));
+	bip->bio_offset = dbtob(FFS_FSBTODB(fs, bno));
 	bip->bio_done = ffs_blkfree_trim_completed;
 	bip->bio_length = size;
 	bip->bio_caller2 = tp;
@@ -2408,7 +2408,7 @@ ffs_checkblk(ip, bno, size)
 	}
 	if ((u_int)bno >= fs->fs_size)
 		panic("ffs_checkblk: bad block %jd", (intmax_t)bno);
-	error = bread(ITODEVVP(ip), fsbtodb(fs, cgtod(fs, dtog(fs, bno))),
+	error = bread(ITODEVVP(ip), FFS_FSBTODB(fs, cgtod(fs, dtog(fs, bno))),
 		(int)fs->fs_cgsize, NOCRED, &bp);
 	if (error)
 		panic("ffs_checkblk: cg bread failed");
@@ -2484,7 +2484,7 @@ ffs_freefile(ump, fs, devvp, ino, mode, wkhd)
 	} else if (devvp->v_type == VCHR) {
 		/* devvp is a normal disk device */
 		dev = devvp->v_rdev;
-		cgbno = fsbtodb(fs, cgtod(fs, cg));
+		cgbno = FFS_FSBTODB(fs, cgtod(fs, cg));
 	} else {
 		bp = NULL;
 		return (0);
@@ -2555,7 +2555,7 @@ ffs_checkfreefile(fs, devvp, ino)
 		cgbno = ffs_fragstoblks(fs, cgtod(fs, cg));
 	} else if (devvp->v_type == VCHR) {
 		/* devvp is a normal disk device */
-		cgbno = fsbtodb(fs, cgtod(fs, cg));
+		cgbno = FFS_FSBTODB(fs, cgtod(fs, cg));
 	} else {
 		return (1);
 	}

--- a/sys/ufs/ffs/ffs_inode.c
+++ b/sys/ufs/ffs/ffs_inode.c
@@ -111,7 +111,7 @@ ffs_update(vp, waitfor)
 		flags = GB_LOCK_NOWAIT;
 loop:
 	error = breadn_flags(ITODEVVP(ip),
-	     fsbtodb(fs, ino_to_fsba(fs, ip->i_number)),
+	     FFS_FSBTODB(fs, ino_to_fsba(fs, ip->i_number)),
 	     (int) fs->fs_bsize, 0, 0, 0, NOCRED, flags, &bp);
 	if (error != 0) {
 		if (error != EBUSY)
@@ -513,7 +513,7 @@ ffs_truncate(vp, length, flags, cred)
 		bn = DIP(ip, i_ib[level]);
 		if (bn != 0) {
 			error = ffs_indirtrunc(ip, indir_lbn[level],
-			    fsbtodb(fs, bn), lastiblock[level], level, &count);
+			    FFS_FSBTODB(fs, bn), lastiblock[level], level, &count);
 			if (error)
 				allerror = error;
 			blocksreleased += count;
@@ -723,7 +723,7 @@ ffs_indirtrunc(ip, lbn, dbn, lastbn, level, countp)
 		if (nb == 0)
 			continue;
 		if (level > SINGLE) {
-			if ((error = ffs_indirtrunc(ip, nlbn, fsbtodb(fs, nb),
+			if ((error = ffs_indirtrunc(ip, nlbn, FFS_FSBTODB(fs, nb),
 			    (ufs2_daddr_t)-1, level - 1, &blkcount)) != 0)
 				allerror = error;
 			blocksreleased += blkcount;
@@ -740,7 +740,7 @@ ffs_indirtrunc(ip, lbn, dbn, lastbn, level, countp)
 		last = lastbn % factor;
 		nb = BAP(ip, i);
 		if (nb != 0) {
-			error = ffs_indirtrunc(ip, nlbn, fsbtodb(fs, nb),
+			error = ffs_indirtrunc(ip, nlbn, FFS_FSBTODB(fs, nb),
 			    last, level - 1, &blkcount);
 			if (error)
 				allerror = error;

--- a/sys/ufs/ffs/ffs_snapshot.c
+++ b/sys/ufs/ffs/ffs_snapshot.c
@@ -490,7 +490,7 @@ restart:
 	i = fs->fs_frag - loc % fs->fs_frag;
 	len = (i == fs->fs_frag) ? 0 : i * fs->fs_fsize;
 	if (len > 0) {
-		if ((error = bread(devvp, fsbtodb(fs, fs->fs_csaddr + loc),
+		if ((error = bread(devvp, FFS_FSBTODB(fs, fs->fs_csaddr + loc),
 		    len, KERNCRED, &bp)) != 0) {
 			brelse(bp);
 			free(copy_fs->fs_csp, M_UFSMNT);
@@ -888,7 +888,7 @@ cgaccount(cg, vp, nbp, passno)
 
 	ip = VTOI(vp);
 	fs = ITOFS(ip);
-	error = bread(ITODEVVP(ip), fsbtodb(fs, cgtod(fs, cg)),
+	error = bread(ITODEVVP(ip), FFS_FSBTODB(fs, cgtod(fs, cg)),
 	    (int)fs->fs_cgsize, KERNCRED, &bp);
 	if (error) {
 		brelse(bp);
@@ -1118,7 +1118,7 @@ indiracct_ufs1(snapvp, cancelvp, level, blkno, lbn, rlbn, remblks,
 	 * up the block number for any blocks that are not in the cache.
 	 */
 	bp = getblk(cancelvp, lbn, fs->fs_bsize, 0, 0, 0);
-	bp->b_blkno = fsbtodb(fs, blkno);
+	bp->b_blkno = FFS_FSBTODB(fs, blkno);
 	if ((bp->b_flags & (B_DONE | B_DELWRI)) == 0 &&
 	    (error = readblock(cancelvp, bp, ffs_fragstoblks(fs, blkno)))) {
 		brelse(bp);
@@ -1402,7 +1402,7 @@ indiracct_ufs2(snapvp, cancelvp, level, blkno, lbn, rlbn, remblks,
 	 * up the block number for any blocks that are not in the cache.
 	 */
 	bp = getblk(cancelvp, lbn, fs->fs_bsize, 0, 0, 0);
-	bp->b_blkno = fsbtodb(fs, blkno);
+	bp->b_blkno = FFS_FSBTODB(fs, blkno);
 	if ((bp->b_flags & (B_DONE | B_DELWRI)) == 0 &&
 	    (error = readblock(cancelvp, bp, ffs_fragstoblks(fs, blkno)))) {
 		brelse(bp);
@@ -2137,7 +2137,7 @@ ffs_bp_snapblk(devvp, bp)
 	if (sn == NULL || TAILQ_FIRST(&sn->sn_head) == NULL)
 		return (0);
 	fs = ITOFS(TAILQ_FIRST(&sn->sn_head));
-	lbn = ffs_fragstoblks(fs, dbtofsb(fs, bp->b_blkno));
+	lbn = ffs_fragstoblks(fs, FFS_DBTOFSB(fs, bp->b_blkno));
 	snapblklist = sn->sn_blklist;
 	upper = sn->sn_listsize - 1;
 	lower = 1;
@@ -2264,7 +2264,7 @@ ffs_copyonwrite(devvp, bp)
 	}
 	ip = TAILQ_FIRST(&sn->sn_head);
 	fs = ITOFS(ip);
-	lbn = ffs_fragstoblks(fs, dbtofsb(fs, bp->b_blkno));
+	lbn = ffs_fragstoblks(fs, FFS_DBTOFSB(fs, bp->b_blkno));
 	snapblklist = sn->sn_blklist;
 	upper = sn->sn_listsize - 1;
 	lower = 1;
@@ -2500,7 +2500,7 @@ readblock(vp, bp, lbn)
 
 	bip = g_alloc_bio();
 	bip->bio_cmd = BIO_READ;
-	bip->bio_offset = dbtob(fsbtodb(fs, ffs_blkstofrags(fs, lbn)));
+	bip->bio_offset = dbtob(FFS_FSBTODB(fs, ffs_blkstofrags(fs, lbn)));
 	bip->bio_data = bp->b_data;
 	bip->bio_length = bp->b_bcount;
 	bip->bio_done = NULL;

--- a/sys/ufs/ffs/ffs_vfsops.c
+++ b/sys/ufs/ffs/ffs_vfsops.c
@@ -683,7 +683,7 @@ ffs_reload(struct mount *mp, struct thread *td, int flags)
 		size = fs->fs_bsize;
 		if (i + fs->fs_frag > blks)
 			size = (blks - i) * fs->fs_fsize;
-		error = bread(devvp, fsbtodb(fs, fs->fs_csaddr + i), size,
+		error = bread(devvp, FFS_FSBTODB(fs, fs->fs_csaddr + i), size,
 		    NOCRED, &bp);
 		if (error)
 			return (error);
@@ -733,7 +733,7 @@ loop:
 		 */
 		ip = VTOI(vp);
 		error =
-		    bread(devvp, fsbtodb(fs, ino_to_fsba(fs, ip->i_number)),
+		    bread(devvp, FFS_FSBTODB(fs, ino_to_fsba(fs, ip->i_number)),
 		    (int)fs->fs_bsize, NOCRED, &bp);
 		if (error) {
 			VOP_UNLOCK(vp, 0);
@@ -938,7 +938,7 @@ ffs_mountfs(devvp, mp, td)
 		size = fs->fs_bsize;
 		if (i + fs->fs_frag > blks)
 			size = (blks - i) * fs->fs_fsize;
-		if ((error = bread(devvp, fsbtodb(fs, fs->fs_csaddr + i), size,
+		if ((error = bread(devvp, FFS_FSBTODB(fs, fs->fs_csaddr + i), size,
 		    cred, &bp)) != 0) {
 			free(fs->fs_csp, M_UFSMNT);
 			goto out;
@@ -1042,7 +1042,7 @@ ffs_mountfs(devvp, mp, td)
 	ump->um_dev = dev;
 	ump->um_devvp = devvp;
 	ump->um_nindir = fs->fs_nindir;
-	ump->um_bptrtodb = fs->fs_fsbtodb;
+	ump->um_bptrtodb = fs->fs_FFS_FSBTODB;
 	ump->um_seqinc = fs->fs_frag;
 	for (i = 0; i < MAXQUOTAS; i++)
 		ump->um_quotas[i] = NULLVP;
@@ -1430,9 +1430,9 @@ ffs_statfs(mp, sbp)
 	sbp->f_blocks = fs->fs_dsize;
 	UFS_LOCK(ump);
 	sbp->f_bfree = fs->fs_cstotal.cs_nbfree * fs->fs_frag +
-	    fs->fs_cstotal.cs_nffree + dbtofsb(fs, fs->fs_pendingblocks);
+	    fs->fs_cstotal.cs_nffree + FFS_DBTOFSB(fs, fs->fs_pendingblocks);
 	sbp->f_bavail = freespace(fs, fs->fs_minfree) +
-	    dbtofsb(fs, fs->fs_pendingblocks);
+	    FFS_DBTOFSB(fs, fs->fs_pendingblocks);
 	sbp->f_files =  fs->fs_ncg * fs->fs_ipg - UFS_ROOTINO;
 	sbp->f_ffree = fs->fs_cstotal.cs_nifree + fs->fs_pendinginodes;
 	UFS_UNLOCK(ump);
@@ -1741,7 +1741,7 @@ ffs_vgetf(mp, ino, flags, vpp, ffs_flags)
 		return (error);
 
 	/* Read in the disk contents for the inode, copy into the inode. */
-	error = bread(ump->um_devvp, fsbtodb(fs, ino_to_fsba(fs, ino)),
+	error = bread(ump->um_devvp, FFS_FSBTODB(fs, ino_to_fsba(fs, ino)),
 	    (int)fs->fs_bsize, NOCRED, &bp);
 	if (error) {
 		/*
@@ -1859,7 +1859,7 @@ ffs_fhtovp(mp, fhp, flags, vpp)
 	if (fs->fs_magic != FS_UFS2_MAGIC)
 		return (ufs_fhtovp(mp, ufhp, flags, vpp));
 	cg = ino_to_cg(fs, ino);
-	error = bread(ump->um_devvp, fsbtodb(fs, cgtod(fs, cg)),
+	error = bread(ump->um_devvp, FFS_FSBTODB(fs, cgtod(fs, cg)),
 		(int)fs->fs_cgsize, NOCRED, &bp);
 	if (error)
 		return (error);
@@ -1934,7 +1934,7 @@ ffs_sbupdate(ump, waitfor, suspended)
 		size = fs->fs_bsize;
 		if (i + fs->fs_frag > blks)
 			size = (blks - i) * fs->fs_fsize;
-		bp = getblk(ump->um_devvp, fsbtodb(fs, fs->fs_csaddr + i),
+		bp = getblk(ump->um_devvp, FFS_FSBTODB(fs, fs->fs_csaddr + i),
 		    size, 0, 0, 0);
 		bcopy(space, bp->b_data, (u_int)size);
 		space = (char *)space + size;

--- a/sys/ufs/ffs/fs.h
+++ b/sys/ufs/ffs/fs.h
@@ -518,8 +518,8 @@ struct cg {
  * Turn filesystem block numbers into disk block addresses.
  * This maps filesystem blocks to device size blocks.
  */
-#define	fsbtodb(fs, b)	((daddr_t)(b) << (fs)->fs_fsbtodb)
-#define	dbtofsb(fs, b)	((b) >> (fs)->fs_fsbtodb)
+#define	FFS_FSBTODB(fs, b)	((daddr_t)(b) << (fs)->fs_fsbtodb)
+#define	FFS_DBTOFSB(fs, b)	((b) >> (fs)->fs_fsbtodb)
 
 /*
  * Cylinder group macros to locate things in cylinder groups.

--- a/sys/ufs/ufs/dir.h
+++ b/sys/ufs/ufs/dir.h
@@ -59,9 +59,9 @@
  * with null bytes.  All names are guaranteed null terminated.
  * The maximum length of a name in a directory is UFS_MAXNAMLEN.
  *
- * The macro DIRSIZ(fmt, dp) gives the amount of space required to represent
+ * The macro UFS_DIRSIZ(fmt, dp) gives the amount of space required to represent
  * a directory entry.  Free space in a directory is represented by
- * entries which have dp->d_reclen > DIRSIZ(fmt, dp).  All UFS_DIRBLKSIZ bytes
+ * entries which have dp->d_reclen > UFS_DIRSIZ(fmt, dp).  All UFS_DIRBLKSIZ bytes
  * in a directory block are claimed by the directory entries.  This
  * usually results in the last entry in a directory having a large
  * dp->d_reclen.  When entries are deleted from a directory, the
@@ -103,25 +103,25 @@ struct	direct {
 #define	DTTOIF(dirtype)	((dirtype) << 12)
 
 /*
- * The DIRSIZ macro gives the minimum record length which will hold
+ * The UFS_DIRSIZ macro gives the minimum record length which will hold
  * the directory entry.  This requires the amount of space in struct direct
  * without the d_name field, plus enough space for the name with a terminating
  * null byte (dp->d_namlen+1), rounded up to a 4 byte boundary.
  *
  * 
  */
-#define	DIRECTSIZ(namlen)						\
+#define	UFS_DIRECTSIZ(namlen)						\
 	((__offsetof(struct direct, d_name) +				\
 	  ((namlen)+1)*sizeof(((struct direct *)0)->d_name[0]) + 3) & ~3)
 #if (BYTE_ORDER == LITTLE_ENDIAN)
-#define	DIRSIZ(oldfmt, dp) \
-    ((oldfmt) ? DIRECTSIZ((dp)->d_type) : DIRECTSIZ((dp)->d_namlen))
+#define	UFS_DIRSIZ(oldfmt, dp) \
+    ((oldfmt) ? UFS_DIRECTSIZ((dp)->d_type) : UFS_DIRECTSIZ((dp)->d_namlen))
 #else
-#define	DIRSIZ(oldfmt, dp) \
-    DIRECTSIZ((dp)->d_namlen)
+#define	UFS_DIRSIZ(oldfmt, dp) \
+    UFS_DIRECTSIZ((dp)->d_namlen)
 #endif
-#define	OLDDIRFMT	1
-#define	NEWDIRFMT	0
+#define	UFS_OLDDIRFMT	1
+#define	UFS_NEWDIRFMT	0
 
 /*
  * Template for manipulating directories.  Should use struct direct's,

--- a/sys/ufs/ufs/dir.h
+++ b/sys/ufs/ufs/dir.h
@@ -47,11 +47,11 @@
 #define	MAXDIRSIZE	(0x7fffffff)
 
 /*
- * A directory consists of some number of blocks of DIRBLKSIZ
- * bytes, where DIRBLKSIZ is chosen such that it can be transferred
+ * A directory consists of some number of blocks of UFS_DIRBLKSIZ
+ * bytes, where UFS_DIRBLKSIZ is chosen such that it can be transferred
  * to disk in a single atomic operation (e.g. 512 bytes on most machines).
  *
- * Each DIRBLKSIZ byte block contains some number of directory entry
+ * Each UFS_DIRBLKSIZ byte block contains some number of directory entry
  * structures, which are of variable length.  Each directory entry has
  * a struct direct at the front of it, containing its inode number,
  * the length of the entry, and the length of the name contained in
@@ -61,7 +61,7 @@
  *
  * The macro DIRSIZ(fmt, dp) gives the amount of space required to represent
  * a directory entry.  Free space in a directory is represented by
- * entries which have dp->d_reclen > DIRSIZ(fmt, dp).  All DIRBLKSIZ bytes
+ * entries which have dp->d_reclen > DIRSIZ(fmt, dp).  All UFS_DIRBLKSIZ bytes
  * in a directory block are claimed by the directory entries.  This
  * usually results in the last entry in a directory having a large
  * dp->d_reclen.  When entries are deleted from a directory, the
@@ -71,7 +71,7 @@
  * Entries other than the first in a directory do not normally have
  * dp->d_ino set to 0.
  */
-#define	DIRBLKSIZ	DEV_BSIZE
+#define	UFS_DIRBLKSIZ	DEV_BSIZE
 #define	UFS_MAXNAMLEN	255
 
 struct	direct {

--- a/sys/ufs/ufs/dirhash.h
+++ b/sys/ufs/ufs/dirhash.h
@@ -48,7 +48,7 @@
 #define	DIRHASH_DEL	(-2)	/* deleted entry; may be part of chain */
 
 #define	DIRALIGN	4
-#define	DH_NFSTATS	(DIRECTSIZ(UFS_MAXNAMLEN + 1) / DIRALIGN)
+#define	DH_NFSTATS	(UFS_DIRECTSIZ(UFS_MAXNAMLEN + 1) / DIRALIGN)
 				 /* max DIRALIGN words in a directory entry */
 
 /*

--- a/sys/ufs/ufs/ufs_dirhash.c
+++ b/sys/ufs/ufs/ufs_dirhash.c
@@ -367,7 +367,7 @@ ufsdirhash_build(struct inode *ip)
 	vp = ip->i_vnode;
 	/* Allocate 50% more entries than this dir size could ever need. */
 	KASSERT(ip->i_size >= UFS_DIRBLKSIZ, ("ufsdirhash_build size"));
-	nslots = ip->i_size / DIRECTSIZ(1);
+	nslots = ip->i_size / UFS_DIRECTSIZ(1);
 	nslots = (nslots * 3 + 1) / 2;
 	narrays = howmany(nslots, DH_NBLKOFF);
 	nslots = narrays * DH_NBLKOFF;
@@ -449,7 +449,7 @@ ufsdirhash_build(struct inode *ip)
 				slot = WRAPINCR(slot, dh->dh_hlen);
 			dh->dh_hused++;
 			DH_ENTRY(dh, slot) = pos;
-			ufsdirhash_adjfree(dh, pos, -DIRSIZ(0, ep));
+			ufsdirhash_adjfree(dh, pos, -UFS_DIRSIZ(0, ep));
 		}
 		pos += ep->d_reclen;
 	}
@@ -653,7 +653,7 @@ restart:
 			}
 
 			/* Update offset. */
-			dh->dh_seqoff = offset + DIRSIZ(0, dp);
+			dh->dh_seqoff = offset + UFS_DIRSIZ(0, dp);
 			*bpp = bp;
 			*offp = offset;
 			ufsdirhash_release(dh);
@@ -729,7 +729,7 @@ ufsdirhash_findfree(struct inode *ip, int slotneeded, int *slotsize)
 			brelse(bp);
 			return (-1);
 		}
-		if (dp->d_ino == 0 || dp->d_reclen > DIRSIZ(0, dp))
+		if (dp->d_ino == 0 || dp->d_reclen > UFS_DIRSIZ(0, dp))
 			break;
 		i += dp->d_reclen;
 		dp = (struct direct *)((char *)dp + dp->d_reclen);
@@ -745,7 +745,7 @@ ufsdirhash_findfree(struct inode *ip, int slotneeded, int *slotsize)
 	while (i < UFS_DIRBLKSIZ && freebytes < slotneeded) {
 		freebytes += dp->d_reclen;
 		if (dp->d_ino != 0)
-			freebytes -= DIRSIZ(0, dp);
+			freebytes -= UFS_DIRSIZ(0, dp);
 		if (dp->d_reclen == 0) {
 			brelse(bp);
 			return (-1);
@@ -827,7 +827,7 @@ ufsdirhash_add(struct inode *ip, struct direct *dirp, doff_t offset)
 	dh->dh_lastused = time_second;
 
 	/* Update the per-block summary info. */
-	ufsdirhash_adjfree(dh, offset, -DIRSIZ(0, dirp));
+	ufsdirhash_adjfree(dh, offset, -UFS_DIRSIZ(0, dirp));
 	ufsdirhash_release(dh);
 }
 
@@ -854,7 +854,7 @@ ufsdirhash_remove(struct inode *ip, struct direct *dirp, doff_t offset)
 	ufsdirhash_delslot(dh, slot);
 
 	/* Update the per-block summary info. */
-	ufsdirhash_adjfree(dh, offset, DIRSIZ(0, dirp));
+	ufsdirhash_adjfree(dh, offset, UFS_DIRSIZ(0, dirp));
 	ufsdirhash_release(dh);
 }
 
@@ -1003,7 +1003,7 @@ ufsdirhash_checkblock(struct inode *ip, char *buf, doff_t offset)
 		/* Check that the entry	exists (will panic if it doesn't). */
 		ufsdirhash_findslot(dh, dp->d_name, dp->d_namlen, offset + i);
 
-		nfree += dp->d_reclen - DIRSIZ(0, dp);
+		nfree += dp->d_reclen - UFS_DIRSIZ(0, dp);
 	}
 	if (i != UFS_DIRBLKSIZ)
 		panic("ufsdirhash_checkblock: bad dir end");

--- a/sys/ufs/ufs/ufs_extattr.c
+++ b/sys/ufs/ufs/ufs_extattr.c
@@ -373,7 +373,7 @@ ufs_extattr_iterate_directory(struct ufsmount *ump, struct vnode *dvp,
 	if (dvp->v_type != VDIR)
 		return (ENOTDIR);
 
-	dirbuf = malloc(DIRBLKSIZ, M_TEMP, M_WAITOK);
+	dirbuf = malloc(UFS_DIRBLKSIZ, M_TEMP, M_WAITOK);
 
 	auio.uio_iov = &aiov;
 	auio.uio_iovcnt = 1;
@@ -391,9 +391,9 @@ ufs_extattr_iterate_directory(struct ufsmount *ump, struct vnode *dvp,
 	vargs.a_cookies = NULL;
 
 	while (!eofflag) {
-		auio.uio_resid = DIRBLKSIZ;
+		auio.uio_resid = UFS_DIRBLKSIZ;
 		aiov.iov_base = dirbuf;
-		aiov.iov_len = DIRBLKSIZ;
+		aiov.iov_len = UFS_DIRBLKSIZ;
 		error = ufs_readdir(&vargs);
 		if (error) {
 			printf("ufs_extattr_iterate_directory: ufs_readdir "
@@ -401,7 +401,7 @@ ufs_extattr_iterate_directory(struct ufsmount *ump, struct vnode *dvp,
 			return (error);
 		}
 
-		edp = (struct dirent *)&dirbuf[DIRBLKSIZ - auio.uio_resid];
+		edp = (struct dirent *)&dirbuf[UFS_DIRBLKSIZ - auio.uio_resid];
 		for (dp = (struct dirent *)dirbuf; dp < edp; ) {
 			if (dp->d_reclen == 0)
 				break;

--- a/sys/ufs/ufs/ufs_gjournal.c
+++ b/sys/ufs/ufs/ufs_gjournal.c
@@ -78,7 +78,7 @@ ufs_gjournal_modref(struct vnode *vp, int count)
 	} else if (devvp->v_type == VCHR) {
 		/* devvp is a normal disk device */
 		dev = devvp->v_rdev;
-		cgbno = fsbtodb(fs, cgtod(fs, cg));
+		cgbno = FFS_FSBTODB(fs, cgtod(fs, cg));
 	} else {
 		bp = NULL;
 		return (EIO);

--- a/sys/ufs/ufs/ufs_lookup.c
+++ b/sys/ufs/ufs/ufs_lookup.c
@@ -273,7 +273,7 @@ restart:
 	if ((nameiop == CREATE || nameiop == RENAME) &&
 	    (flags & ISLASTCN)) {
 		slotstatus = NONE;
-		slotneeded = DIRECTSIZ(cnp->cn_namelen);
+		slotneeded = UFS_DIRECTSIZ(cnp->cn_namelen);
 	}
 
 #ifdef UFS_DIRHASH
@@ -394,7 +394,7 @@ searchloop:
 			int size = ep->d_reclen;
 
 			if (ep->d_ino != 0)
-				size -= DIRSIZ(OFSFMT(vdp), ep);
+				size -= UFS_DIRSIZ(OFSFMT(vdp), ep);
 			if (size > 0) {
 				if (size >= slotneeded) {
 					slotstatus = FOUND;
@@ -550,9 +550,9 @@ found:
 	 * Check that directory length properly reflects presence
 	 * of this entry.
 	 */
-	if (i_offset + DIRSIZ(OFSFMT(vdp), ep) > dp->i_size) {
+	if (i_offset + UFS_DIRSIZ(OFSFMT(vdp), ep) > dp->i_size) {
 		ufs_dirbad(dp, i_offset, "i_size too small");
-		dp->i_size = i_offset + DIRSIZ(OFSFMT(vdp), ep);
+		dp->i_size = i_offset + UFS_DIRSIZ(OFSFMT(vdp), ep);
 		DIP_SET(dp, i_size, dp->i_size);
 		dp->i_flag |= IN_CHANGE | IN_UPDATE;
 	}
@@ -792,7 +792,7 @@ ufs_dirbadentry(dp, ep, entryoffsetinblock)
 #	endif
 	if ((ep->d_reclen & 0x3) != 0 ||
 	    ep->d_reclen > UFS_DIRBLKSIZ - (entryoffsetinblock & (UFS_DIRBLKSIZ - 1)) ||
-	    ep->d_reclen < DIRSIZ(OFSFMT(dp), ep) || namlen > UFS_MAXNAMLEN) {
+	    ep->d_reclen < UFS_DIRSIZ(OFSFMT(dp), ep) || namlen > UFS_MAXNAMLEN) {
 		/*return (1); */
 		printf("First bad\n");
 		goto bad;
@@ -876,7 +876,7 @@ ufs_direnter(dvp, tvp, dirp, cnp, newdirbp, isrename)
 	cr = td->td_ucred;
 
 	dp = VTOI(dvp);
-	newentrysize = DIRSIZ(OFSFMT(dvp), dirp);
+	newentrysize = UFS_DIRSIZ(OFSFMT(dvp), dirp);
 
 	if (dp->i_count == 0) {
 		/*
@@ -1012,7 +1012,7 @@ ufs_direnter(dvp, tvp, dirp, cnp, newdirbp, isrename)
 	 * dp->i_offset + dp->i_count would yield the space.
 	 */
 	ep = (struct direct *)dirbuf;
-	dsize = ep->d_ino ? DIRSIZ(OFSFMT(dvp), ep) : 0;
+	dsize = ep->d_ino ? UFS_DIRSIZ(OFSFMT(dvp), ep) : 0;
 	spacefree = ep->d_reclen - dsize;
 	for (loc = ep->d_reclen; loc < dp->i_count; ) {
 		nep = (struct direct *)(dirbuf + loc);
@@ -1037,7 +1037,7 @@ ufs_direnter(dvp, tvp, dirp, cnp, newdirbp, isrename)
 			dsize = 0;
 			continue;
 		}
-		dsize = DIRSIZ(OFSFMT(dvp), nep);
+		dsize = UFS_DIRSIZ(OFSFMT(dvp), nep);
 		spacefree += nep->d_reclen - dsize;
 #ifdef UFS_DIRHASH
 		if (dp->i_dirhash != NULL)

--- a/sys/ufs/ufs/ufs_vnops.c
+++ b/sys/ufs/ufs/ufs_vnops.c
@@ -131,11 +131,11 @@ SYSCTL_NODE(_vfs, OID_AUTO, ufs, CTLFLAG_RD, 0, "UFS filesystem");
  */
 static struct dirtemplate mastertemplate = {
 	0, 12, DT_DIR, 1, ".",
-	0, DIRBLKSIZ - 12, DT_DIR, 2, ".."
+	0, UFS_DIRBLKSIZ - 12, DT_DIR, 2, ".."
 };
 static struct odirtemplate omastertemplate = {
 	0, 12, 1, ".",
-	0, DIRBLKSIZ - 12, 2, ".."
+	0, UFS_DIRBLKSIZ - 12, 2, ".."
 };
 
 static void
@@ -1940,12 +1940,12 @@ ufs_mkdir(ap)
 	dirtemplate = *dtp;
 	dirtemplate.dot_ino = ip->i_number;
 	dirtemplate.dotdot_ino = dp->i_number;
-	vnode_pager_setsize(tvp, DIRBLKSIZ);
-	if ((error = UFS_BALLOC(tvp, (off_t)0, DIRBLKSIZ, cnp->cn_cred,
+	vnode_pager_setsize(tvp, UFS_DIRBLKSIZ);
+	if ((error = UFS_BALLOC(tvp, (off_t)0, UFS_DIRBLKSIZ, cnp->cn_cred,
 	    BA_CLRBUF, &bp)) != 0)
 		goto bad;
-	ip->i_size = DIRBLKSIZ;
-	DIP_SET(ip, i_size, DIRBLKSIZ);
+	ip->i_size = UFS_DIRBLKSIZ;
+	DIP_SET(ip, i_size, UFS_DIRBLKSIZ);
 	ip->i_flag |= IN_CHANGE | IN_UPDATE;
 	bcopy((caddr_t)&dirtemplate, (caddr_t)bp->b_data, sizeof dirtemplate);
 	if (DOINGSOFTDEP(tvp)) {
@@ -1955,11 +1955,11 @@ ufs_mkdir(ap)
 		 * block does not have to ensure that the block is
 		 * written before the inode.
 		 */
-		blkoff = DIRBLKSIZ;
+		blkoff = UFS_DIRBLKSIZ;
 		while (blkoff < bp->b_bcount) {
 			((struct direct *)
-			   (bp->b_data + blkoff))->d_reclen = DIRBLKSIZ;
-			blkoff += DIRBLKSIZ;
+			   (bp->b_data + blkoff))->d_reclen = UFS_DIRBLKSIZ;
+			blkoff += UFS_DIRBLKSIZ;
 		}
 	}
 	if ((error = UFS_UPDATE(tvp, !DOINGSOFTDEP(tvp) &&
@@ -2203,7 +2203,7 @@ ufs_readdir(ap)
 		else
 			readcnt = bp->b_bcount;
 		skipcnt = (size_t)(uio->uio_offset - bp->b_offset) &
-		    ~(size_t)(DIRBLKSIZ - 1);
+		    ~(size_t)(UFS_DIRBLKSIZ - 1);
 		offset = bp->b_offset + skipcnt;
 		dp = (struct direct *)&bp->b_data[skipcnt];
 		edp = (struct direct *)&bp->b_data[readcnt];

--- a/usr.sbin/makefs/ffs.c
+++ b/usr.sbin/makefs/ffs.c
@@ -593,12 +593,12 @@ ffs_size_dir(fsnode *root, fsinfo_t *fsopts)
 
 #define	ADDDIRENT(e) do {						\
 	tmpdir.d_namlen = strlen((e));					\
-	this = DIRSIZ_SWAP(0, &tmpdir, 0);					\
+	this = DIRSIZ_SWAP(0, &tmpdir, 0);				\
 	if (debug & DEBUG_FS_SIZE_DIR_ADD_DIRENT)			\
 		printf("ADDDIRENT: was: %s (%d) this %d cur %d\n",	\
 		    e, tmpdir.d_namlen, this, curdirsize);		\
-	if (this + curdirsize > roundup(curdirsize, DIRBLKSIZ))		\
-		curdirsize = roundup(curdirsize, DIRBLKSIZ);		\
+	if (this + curdirsize > roundup(curdirsize, UFS_DIRBLKSIZ))	\
+		curdirsize = roundup(curdirsize, UFS_DIRBLKSIZ);	\
 	curdirsize += this;						\
 	if (debug & DEBUG_FS_SIZE_DIR_ADD_DIRENT)			\
 		printf("ADDDIRENT: now: %s (%d) this %d cur %d\n",	\
@@ -1043,15 +1043,15 @@ ffs_make_dirbuf(dirbuf_t *dbuf, const char *name, fsnode *node, int needswap)
 		    ufs_rw32(de.d_ino, needswap), de.d_type, reclen,
 		    de.d_namlen, de.d_name);
 
-	if (reclen + dbuf->cur + llen > roundup(dbuf->size, DIRBLKSIZ)) {
+	if (reclen + dbuf->cur + llen > roundup(dbuf->size, UFS_DIRBLKSIZ)) {
 		if (debug & DEBUG_FS_MAKE_DIRBUF)
 			printf("ffs_make_dirbuf: growing buf to %d\n",
-			    dbuf->size + DIRBLKSIZ);
-		newbuf = erealloc(dbuf->buf, dbuf->size + DIRBLKSIZ);
+			    dbuf->size + UFS_DIRBLKSIZ);
+		newbuf = erealloc(dbuf->buf, dbuf->size + UFS_DIRBLKSIZ);
 		dbuf->buf = newbuf;
-		dbuf->size += DIRBLKSIZ;
-		memset(dbuf->buf + dbuf->size - DIRBLKSIZ, 0, DIRBLKSIZ);
-		dbuf->cur = dbuf->size - DIRBLKSIZ;
+		dbuf->size += UFS_DIRBLKSIZ;
+		memset(dbuf->buf + dbuf->size - UFS_DIRBLKSIZ, 0, UFS_DIRBLKSIZ);
+		dbuf->cur = dbuf->size - UFS_DIRBLKSIZ;
 	} else if (dp) {			/* shrink end of previous */
 		dp->d_reclen = ufs_rw16(llen,needswap);
 		dbuf->cur += llen;

--- a/usr.sbin/makefs/ffs.c
+++ b/usr.sbin/makefs/ffs.c
@@ -1090,7 +1090,7 @@ ffs_write_inode(union dinode *dp, uint32_t ino, const fsinfo_t *fsopts)
 		printf("ffs_write_inode: din %p ino %u cg %d cgino %d\n",
 		    dp, ino, cg, cgino);
 
-	ffs_rdfs(fsbtodb(fs, cgtod(fs, cg)), (int)fs->fs_cgsize, &sbbuf,
+	ffs_rdfs(FFS_FSBTODB(fs, cgtod(fs, cg)), (int)fs->fs_cgsize, &sbbuf,
 	    fsopts);
 	cgp = (struct cg *)(void *)sbbuf;
 	if (!cg_chkmagic_swap(cgp, fsopts->needswap))
@@ -1133,7 +1133,7 @@ ffs_write_inode(union dinode *dp, uint32_t ino, const fsinfo_t *fsopts)
 			dip->di_gen = random();
 			dip++;
 		}
-		ffs_wtfs(fsbtodb(fs, ino_to_fsba(fs,
+		ffs_wtfs(FFS_FSBTODB(fs, ino_to_fsba(fs,
 				  cg * fs->fs_ipg + initediblk)),
 		    fs->fs_bsize, buf, fsopts);
 		initediblk += FFS_INOPB(fs);
@@ -1141,11 +1141,11 @@ ffs_write_inode(union dinode *dp, uint32_t ino, const fsinfo_t *fsopts)
 	}
 
 
-	ffs_wtfs(fsbtodb(fs, cgtod(fs, cg)), (int)fs->fs_cgsize, &sbbuf,
+	ffs_wtfs(FFS_FSBTODB(fs, cgtod(fs, cg)), (int)fs->fs_cgsize, &sbbuf,
 	    fsopts);
 
 					/* now write inode */
-	d = fsbtodb(fs, ino_to_fsba(fs, ino));
+	d = FFS_FSBTODB(fs, ino_to_fsba(fs, ino));
 	ffs_rdfs(d, fs->fs_bsize, buf, fsopts);
 	if (fsopts->needswap) {
 		if (ffs_opts->version == 1)

--- a/usr.sbin/makefs/ffs/ffs_alloc.c
+++ b/usr.sbin/makefs/ffs/ffs_alloc.c
@@ -302,7 +302,7 @@ ffs_alloccg(struct inode *ip, int cg, daddr_t bpref, int size)
 
 	if (fs->fs_cs(fs, cg).cs_nbfree == 0 && size == fs->fs_bsize)
 		return (0);
-	error = bread(&vp, fsbtodb(fs, cgtod(fs, cg)), (int)fs->fs_cgsize,
+	error = bread(&vp, FFS_FSBTODB(fs, cgtod(fs, cg)), (int)fs->fs_cgsize,
 	    NULL, &bp);
 	if (error) {
 		brelse(bp, 0);
@@ -447,7 +447,7 @@ ffs_blkfree(struct inode *ip, daddr_t bno, long size)
 		    (uintmax_t)ip->i_number);
 		return;
 	}
-	error = bread(&vp, fsbtodb(fs, cgtod(fs, cg)), (int)fs->fs_cgsize,
+	error = bread(&vp, FFS_FSBTODB(fs, cgtod(fs, cg)), (int)fs->fs_cgsize,
 	    NULL, &bp);
 	if (error) {
 		brelse(bp, 0);

--- a/usr.sbin/makefs/ffs/ffs_balloc.c
+++ b/usr.sbin/makefs/ffs/ffs_balloc.c
@@ -190,7 +190,7 @@ ffs_balloc_ufs1(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 				return (error);
 			if (bpp != NULL) {
 				bp = getblk(&vp, lbn, nsize, 0, 0, 0);
-				bp->b_blkno = fsbtodb(fs, newb);
+				bp->b_blkno = FFS_FSBTODB(fs, newb);
 				clrbuf(bp);
 				*bpp = bp;
 			}
@@ -228,7 +228,7 @@ ffs_balloc_ufs1(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 		nb = newb;
 		*allocblk++ = nb;
 		bp = getblk(&vp, indirs[1].in_lbn, fs->fs_bsize, 0, 0, 0);
-		bp->b_blkno = fsbtodb(fs, nb);
+		bp->b_blkno = FFS_FSBTODB(fs, nb);
 		clrbuf(bp);
 		/*
 		 * Write synchronously so that indirect blocks
@@ -269,7 +269,7 @@ ffs_balloc_ufs1(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 		nb = newb;
 		*allocblk++ = nb;
 		nbp = getblk(&vp, indirs[i].in_lbn, fs->fs_bsize, 0, 0, 0);
-		nbp->b_blkno = fsbtodb(fs, nb);
+		nbp->b_blkno = FFS_FSBTODB(fs, nb);
 		clrbuf(nbp);
 		/*
 		 * Write synchronously so that indirect blocks
@@ -300,7 +300,7 @@ ffs_balloc_ufs1(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 		*allocblk++ = nb;
 		if (bpp != NULL) {
 			nbp = getblk(&vp, lbn, fs->fs_bsize, 0, 0, 0);
-			nbp->b_blkno = fsbtodb(fs, nb);
+			nbp->b_blkno = FFS_FSBTODB(fs, nb);
 			clrbuf(nbp);
 			*bpp = nbp;
 		}
@@ -441,7 +441,7 @@ ffs_balloc_ufs2(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 				return (error);
 			if (bpp != NULL) {
 				bp = getblk(&vp, lbn, nsize, 0, 0, 0);
-				bp->b_blkno = fsbtodb(fs, newb);
+				bp->b_blkno = FFS_FSBTODB(fs, newb);
 				clrbuf(bp);
 				*bpp = bp;
 			}
@@ -479,7 +479,7 @@ ffs_balloc_ufs2(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 		nb = newb;
 		*allocblk++ = nb;
 		bp = getblk(&vp, indirs[1].in_lbn, fs->fs_bsize, 0, 0, 0);
-		bp->b_blkno = fsbtodb(fs, nb);
+		bp->b_blkno = FFS_FSBTODB(fs, nb);
 		clrbuf(bp);
 		/*
 		 * Write synchronously so that indirect blocks
@@ -520,7 +520,7 @@ ffs_balloc_ufs2(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 		nb = newb;
 		*allocblk++ = nb;
 		nbp = getblk(&vp, indirs[i].in_lbn, fs->fs_bsize, 0, 0, 0);
-		nbp->b_blkno = fsbtodb(fs, nb);
+		nbp->b_blkno = FFS_FSBTODB(fs, nb);
 		clrbuf(nbp);
 		/*
 		 * Write synchronously so that indirect blocks
@@ -551,7 +551,7 @@ ffs_balloc_ufs2(struct inode *ip, off_t offset, int bufsize, struct buf **bpp)
 		*allocblk++ = nb;
 		if (bpp != NULL) {
 			nbp = getblk(&vp, lbn, fs->fs_bsize, 0, 0, 0);
-			nbp->b_blkno = fsbtodb(fs, nb);
+			nbp->b_blkno = FFS_FSBTODB(fs, nb);
 			clrbuf(nbp);
 			*bpp = nbp;
 		}

--- a/usr.sbin/makefs/ffs/mkfs.c
+++ b/usr.sbin/makefs/ffs/mkfs.c
@@ -250,7 +250,7 @@ ffs_mkfs(const char *fsys, const fsinfo_t *fsopts, time_t tstamp)
 	}
 	sblock.fs_fsbtodb = ilog2(sblock.fs_fsize / sectorsize);
 	sblock.fs_size = sblock.fs_providersize = fssize =
-	    dbtofsb(&sblock, fssize);
+	    FFS_DBTOFSB(&sblock, fssize);
 
 	if (Oflag <= 1) {
 		sblock.fs_magic = FS_UFS1_MAGIC;
@@ -465,7 +465,7 @@ ffs_mkfs(const char *fsys, const fsinfo_t *fsopts, time_t tstamp)
 	printf("%s: %.1fMB (%lld sectors) block size %d, "
 	       "fragment size %d\n",
 	    fsys, (float)sblock.fs_size * sblock.fs_fsize * B2MBFACTOR,
-	    (long long)fsbtodb(&sblock, sblock.fs_size),
+	    (long long)FFS_FSBTODB(&sblock, sblock.fs_size),
 	    sblock.fs_bsize, sblock.fs_fsize);
 	printf("\tusing %d cylinder groups of %.2fMB, %d blks, "
 	       "%d inodes.\n",
@@ -479,7 +479,7 @@ ffs_mkfs(const char *fsys, const fsinfo_t *fsopts, time_t tstamp)
 	 * subwindows in sysinst.
 	 */
 	printcolwidth = count_digits(
-			fsbtodb(&sblock, cgsblock(&sblock, sblock.fs_ncg -1)));
+			FFS_FSBTODB(&sblock, cgsblock(&sblock, sblock.fs_ncg -1)));
 	nprintcols = 76 / (printcolwidth + 2);
 
 	/*
@@ -506,7 +506,7 @@ ffs_mkfs(const char *fsys, const fsinfo_t *fsopts, time_t tstamp)
 		if (cylno % nprintcols == 0)
 			printf("\n");
 		printf(" %*lld,", printcolwidth,
-			(long long)fsbtodb(&sblock, cgsblock(&sblock, cylno)));
+			(long long)FFS_FSBTODB(&sblock, cgsblock(&sblock, cylno)));
 		fflush(stdout);
 	}
 	printf("\n");
@@ -550,7 +550,7 @@ ffs_write_superblock(struct fs *fs, const fsinfo_t *fsopts)
 
 	/* Write out the duplicate super blocks */
 	for (cylno = 0; cylno < fs->fs_ncg; cylno++)
-		ffs_wtfs(fsbtodb(fs, cgsblock(fs, cylno)),
+		ffs_wtfs(FFS_FSBTODB(fs, cgsblock(fs, cylno)),
 		    sbsize, writebuf, fsopts);
 
 	/* Write out the cylinder group summaries */
@@ -567,7 +567,7 @@ ffs_write_superblock(struct fs *fs, const fsinfo_t *fsopts)
 			    (struct csum *)(void *)wrbuf, size);
 		else
 			memcpy(wrbuf, space, (u_int)size);
-		ffs_wtfs(fsbtodb(fs, fs->fs_csaddr + i), size, wrbuf, fsopts);
+		ffs_wtfs(FFS_FSBTODB(fs, fs->fs_csaddr + i), size, wrbuf, fsopts);
 		space = (char *)space + size;
 	}
 	free(wrbuf);
@@ -741,7 +741,7 @@ initcg(int cylno, time_t utime, const fsinfo_t *fsopts)
 			dp2++;
 		}
 	}
-	ffs_wtfs(fsbtodb(&sblock, cgsblock(&sblock, cylno)), iobufsize, iobuf,
+	ffs_wtfs(FFS_FSBTODB(&sblock, cgsblock(&sblock, cylno)), iobufsize, iobuf,
 	    fsopts);
 	/*
 	 * For the old file system, we have to initialize all the inodes.
@@ -755,7 +755,7 @@ initcg(int cylno, time_t utime, const fsinfo_t *fsopts)
 				dp1->di_gen = random();
 				dp1++;
 			}
-			ffs_wtfs(fsbtodb(&sblock, cgimin(&sblock, cylno) + i),
+			ffs_wtfs(FFS_FSBTODB(&sblock, cgimin(&sblock, cylno) + i),
 			    sblock.fs_bsize, &iobuf[start], fsopts);
 		}
 	}

--- a/usr.sbin/makefs/makefs.h
+++ b/usr.sbin/makefs/makefs.h
@@ -277,11 +277,11 @@ extern	struct stat stampst;
 #if (BYTE_ORDER == LITTLE_ENDIAN)
 #define DIRSIZ_SWAP(oldfmt, dp, needswap)      \
     (((oldfmt) && !(needswap)) ?       \
-    DIRECTSIZ((dp)->d_type) : DIRECTSIZ((dp)->d_namlen))
+    UFS_DIRECTSIZ((dp)->d_type) : UFS_DIRECTSIZ((dp)->d_namlen))
 #else
 #define DIRSIZ_SWAP(oldfmt, dp, needswap)      \
     (((oldfmt) && (needswap)) ?                \
-    DIRECTSIZ((dp)->d_type) : DIRECTSIZ((dp)->d_namlen))
+    UFS_DIRECTSIZ((dp)->d_type) : UFS_DIRECTSIZ((dp)->d_namlen))
 #endif
 
 #define        cg_chkmagic_swap(cgp, ns) \


### PR DESCRIPTION
Similar to your previous commit with prefixing macros with "FFS_", I did not modify any macros relevant to the other filesystems (e.g. ext2). If you'd like those changes too, I will add another commit to implement this